### PR TITLE
修复打包出来的文件 resource 文件和内容文件相反

### DIFF
--- a/src/dotnetCampus.SourceYard/Utils/ItemGroupElement.cs
+++ b/src/dotnetCampus.SourceYard/Utils/ItemGroupElement.cs
@@ -27,8 +27,8 @@ namespace dotnetCampus.SourceYard.Utils
 
             var elementList = new List<XElement>();
             elementList.AddRange(IncludingItemCompileFileToElement(compileFileList, "Compile", false));
-            elementList.AddRange(IncludingItemCompileFileToElement(contentFileList, "Resource", true));
-            elementList.AddRange(IncludingItemCompileFileToElement(resourceFileList, "Content", true));
+            elementList.AddRange(IncludingItemCompileFileToElement(resourceFileList, "Resource", true));
+            elementList.AddRange(IncludingItemCompileFileToElement(contentFileList, "Content", true));
             elementList.AddRange(IncludingItemCompileFileToElement(embeddedResource, "EmbeddedResource", true));
             elementList.AddRange(IncludingItemCompileFileToElement(noneFileList, "None", true));
 


### PR DESCRIPTION

原因 之前的  resourceFileList 和内容写反

```
AddRange(IncludingItemCompileFileToElement(resourceFileList, "Resource", true));
AddRange(IncludingItemCompileFileToElement(contentFileList, "Content", true));
```
