### PR TITLE
让文件引用相对可以拿到

### DIFF
--- a/src/dotnetCampus.SourceYard/Utils/ItemGroupElement.cs
+++ b/src/dotnetCampus.SourceYard/Utils/ItemGroupElement.cs
@@ -96,6 +96,8 @@ namespace dotnetCampus.SourceYard.Utils
         private void SetItemElement(XElement element, bool copyToOutputDirectory, string file)
         {
             element.SetAttributeValue("Include", file);
+            element.SetAttributeValue("Link", "%(RecursiveDir)%(Filename)%(Extension)");
+
             if (_isVisible)
             {
                 element.SetAttributeValue("Visible", "True");


### PR DESCRIPTION
解决文件引用相对文件因为源代码安装的相对路径找到文件

https://github.com/dotnet-campus/SourceYard/issues/9