### PR TITLE
添加对 WPF 的支持

### DIFF
--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
-  <Target Name="SourceYard" AfterTargets="Build"
+  <Target Name="SourceYard" AfterTargets="AfterBuild"
           Condition="$(PackSource) != 'False'">
     <PropertyGroup>
       <SourcePackingDirectory>$(IntermediateOutputPath)SourcePacking\</SourcePackingDirectory>

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
@@ -1,7 +1,15 @@
 ﻿<Project>
 
-  <ItemGroup>
-    <SourceReference Include="#(PackageId)" />
-  </ItemGroup>
-  
+    <ItemGroup>
+        <SourceReference Include="#(PackageId)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <!-- 当生成 WPF 临时项目时，不会自动 Import NuGet 中的 props 和 targets 文件，这使得在临时项目中你现在看到的整个文件都不会参与编译。
+          然而，我们可以通过欺骗的方式在主项目中通过 _GeneratedCodeFiles 集合将需要编译的文件传递到临时项目中以间接参与编译。
+          WPF 临时项目不会 Import NuGet 中的 props 和 targets 可能是 WPF 的 Bug，也可能是刻意如此。
+          所以我们通过一个属性开关 `ShouldFixNuGetImportingBugForWpfProjects` 来决定是否修复这个错误。-->
+        <ShouldFixNuGetImportingBugForWpfProjects Condition=" '$(ShouldFixNuGetImportingBugForWpfProjects)' == '' ">True</ShouldFixNuGetImportingBugForWpfProjects>
+    </PropertyGroup>
+
 </Project>

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
@@ -1,5 +1,27 @@
 ﻿<Project>
 
+  <PropertyGroup Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
+    <_#(PackageGuid)ImportInWpfTempProjectDependsOn>
+      _#(PackageGuid)IncludeSourceCodes
+    </_#(PackageGuid)ImportInWpfTempProjectDependsOn>
+
+    <_#(PackageGuid)ImportInWpfXamlDependsOn>
+      _#(PackageGuid)XamlItemGroupIncludeSourceCodes
+    </_#(PackageGuid)ImportInWpfXamlDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))">
+    <_#(PackageGuid)ImportInWpfTempProjectDependsOn>
+      _#(PackageGuid)IncludeSOURCE_REFERENCESourceCodes
+    </_#(PackageGuid)ImportInWpfTempProjectDependsOn>
+
+    <_#(PackageGuid)ImportInWpfXamlDependsOn>
+      _#(PackageGuid)IncludeXamlItemGroupSOURCE_REFERENCESourceCodes
+    </_#(PackageGuid)ImportInWpfXamlDependsOn>
+  </PropertyGroup>
+
+  
+
   <PropertyGroup Condition=" !$(DefineConstants.Contains('SOURCE_REFERENCE')) ">
     <DefineConstants>$(DefineConstants);SOURCE_REFERENCE</DefineConstants>
   </PropertyGroup>
@@ -20,24 +42,64 @@
     <WriteLinesToFile File="$(MSBuildProjectDirectory)/SourceProject/.gitignore" Lines=".gitignore;/*.Source.SourceProject.props" Overwrite="true" />
   </Target>
 
-  <Target Name="_#(PackageGuid)IncludeSourceCodes" BeforeTargets="CoreCompile" Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
+  <Target Name="_#(PackageGuid)IncludeSourceCodes" 
+    Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
     <!-- 只有在不没有找到本地代码的文件时，才使用 nuget 的库 -->
     <!--替换ItemGroup-->
   </Target>
 
-  <Target Name="_#(PackageGuid)XamlItemGroupIncludeSourceCodes" BeforeTargets="GenerateBindingRedirects" Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
+  <Target Name="_#(PackageGuid)XamlItemGroupIncludeSourceCodes" 
+    Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
     <!-- 只有在不没有找到本地代码的文件时，才使用 nuget 的库 -->
     <!--替换XmlItemGroup-->
   </Target>
 
-  <Target Name="_#(PackageGuid)IncludeSOURCE_REFERENCESourceCodes" BeforeTargets="CoreCompile" Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))">
+  <Target Name="_#(PackageGuid)IncludeSOURCE_REFERENCESourceCodes" 
+    Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))">
     <!-- 如果可以找到本地代码，就打开用户代码可以调试 -->
     <!--替换 SOURCE_REFERENCE ItemGroup-->
   </Target>
 
-  <Target Name="_#(PackageGuid)IncludeXamlItemGroupSOURCE_REFERENCESourceCodes" BeforeTargets="GenerateBindingRedirects" Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))">
+  <Target Name="_#(PackageGuid)IncludeXamlItemGroupSOURCE_REFERENCESourceCodes" 
+    Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))">
     <!-- 如果可以找到本地代码，就打开用户代码可以调试 -->
     <!--替换 SOURCE_REFERENCE XmlItemGroup-->
+
+  </Target>
+
+
+
+  <!-- 当生成 WPF 临时项目时，不会自动 Import NuGet 中的 props 和 targets 文件，这使得在临时项目中你现在看到的整个文件都不会参与编译。
+       然而，我们可以通过欺骗的方式在主项目中通过 _GeneratedCodeFiles 集合将需要编译的文件传递到临时项目中以间接参与编译。
+       WPF 临时项目不会 Import NuGet 中的 props 和 targets 可能是 WPF 的 Bug，也可能是刻意如此。
+       所以我们通过一个属性开关 `ShouldFixNuGetImportingBugForWpfProjects` 来决定是否修复这个错误。-->
+
+  <Target Name="_#(PackageGuid)ImportInWpfTempProject"
+          AfterTargets="MarkupCompilePass1"
+          BeforeTargets="GenerateTemporaryTargetAssembly"
+          DependsOnTargets="$(_#(PackageGuid)ImportInWpfTempProjectDependsOn)"
+          Condition=" '$(ShouldFixNuGetImportingBugForWpfProjects)' == 'True' ">
+    <ItemGroup>
+      <_GeneratedCodeFiles Include="@(_#(PackageGuid)Compile)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- 正式项目 -->
+  <Target Name="_#(PackageGuid)ImportInWpfProject"
+     BeforeTargets="CoreCompile" DependsOnTargets="$(_#(PackageGuid)ImportInWpfTempProjectDependsOn)">
+    <ItemGroup>
+      <Compile Include="@(_#(PackageGuid)Compile)"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_#(PackageGuid)IncludeWpfFiles"
+          BeforeTargets="MarkupCompilePass1"
+          DependsOnTargets="$(_#(PackageGuid)ImportInWpfXamlDependsOn)">
+    <ItemGroup>
+      <Page Include="@(_#(PackageGuid)Page)"  />
+      <Resource Include="@(_#(PackageGuid)Resource)"  />
+    </ItemGroup>
+    <Message Text="引用 WPF 相关源码：@(_#(PackageGuid)Page);@(_#(PackageGuid)Resource)" />
   </Target>
 
 </Project>

--- a/src/dotnetCampus.SourceYard/PackFlow/ItemGroupPacker.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/ItemGroupPacker.cs
@@ -43,14 +43,16 @@ namespace dotnetCampus.SourceYard.PackFlow
             // 读取文件
             var buildfile = File.ReadAllText(buildAssetsFile);
 
-            buildfile = ReplaceString(context.PackagedProjectFile, buildfile, sourceReferenceSourceFolder, false,
+            buildfile = ReplaceString(context.PackagedProjectFile, buildfile, context.PackageGuid,
+                sourceReferenceSourceFolder, false,
                 "<!--替换ItemGroup-->", "<!--替换XmlItemGroup-->");
 
             // 本地的代码，用于调试本地的代码
-            
+
             sourceReferenceSourceFolder = $@"$({context.PackageGuid}SourceFolder)\";
 
-            buildfile = ReplaceString(context.PackagedProjectFile, buildfile, sourceReferenceSourceFolder, true,
+            buildfile = ReplaceString(context.PackagedProjectFile, buildfile, context.PackageGuid,
+                sourceReferenceSourceFolder, true,
                 "<!--替换 SOURCE_REFERENCE ItemGroup-->", "<!--替换 SOURCE_REFERENCE XmlItemGroup-->");
 
             // 用户可以选择使用 nuget 源代码，也可以选择使用自己的代码，所以就需要使用两个不同的值
@@ -59,10 +61,12 @@ namespace dotnetCampus.SourceYard.PackFlow
             File.WriteAllText(buildAssetsFile, buildfile);
         }
 
-        private string ReplaceString(PackagedProjectFile contextPackagedProjectFile,string str, string filePath, bool isVisible,
-            string replaceItemGroup,string replaceXmlItemGroup)
+        private string ReplaceString(PackagedProjectFile contextPackagedProjectFile, string str,
+            string packageGuid, string filePath, bool isVisible,
+            string replaceItemGroup, string replaceXmlItemGroup)
         {
-            var groupElement = new ItemGroupElement(contextPackagedProjectFile, filePath, isVisible);
+            var groupElement =
+                new ItemGroupElement(contextPackagedProjectFile, filePath, isVisible, packageGuid);
             var (itemGroupElement, itemGroupElementOfXaml) = groupElement.GetItemGroup();
 
             return str.Replace(replaceItemGroup, itemGroupElement.ToString())

--- a/src/dotnetCampus.SourceYard/Utils/ItemGroupElement.cs
+++ b/src/dotnetCampus.SourceYard/Utils/ItemGroupElement.cs
@@ -8,11 +8,13 @@ namespace dotnetCampus.SourceYard.Utils
     class ItemGroupElement
     {
         /// <inheritdoc />
-        public ItemGroupElement(PackagedProjectFile contextPackagedProjectFile, string filePath, bool isVisible)
+        public ItemGroupElement(PackagedProjectFile contextPackagedProjectFile, string filePath, bool isVisible,
+            string packageGuid)
         {
             _contextPackagedProjectFile = contextPackagedProjectFile;
             _filePath = filePath;
             _isVisible = isVisible;
+            _packageGuid = packageGuid;
         }
 
         public (XElement itemGroupElement, XElement itemGroupElementOfXaml) GetItemGroup()
@@ -25,17 +27,20 @@ namespace dotnetCampus.SourceYard.Utils
             var embeddedResource = GetFileList(contextPackagedProjectFile.EmbeddedResource);
             var pageFileList = GetFileList(contextPackagedProjectFile.Page);
 
+            var prefix = $"_{_packageGuid}";
+
             var elementList = new List<XElement>();
-            elementList.AddRange(IncludingItemCompileFileToElement(compileFileList, "Compile", false));
-            elementList.AddRange(IncludingItemCompileFileToElement(resourceFileList, "Resource", true));
-            elementList.AddRange(IncludingItemCompileFileToElement(contentFileList, "Content", true));
-            elementList.AddRange(IncludingItemCompileFileToElement(embeddedResource, "EmbeddedResource", true));
+            elementList.AddRange(IncludingItemCompileFileToElement(compileFileList, $"{prefix}Compile", false));
+       
+            elementList.AddRange(IncludingItemCompileFileToElement(contentFileList, $"Content", true));
+            elementList.AddRange(IncludingItemCompileFileToElement(embeddedResource, $"EmbeddedResource", true));
             elementList.AddRange(IncludingItemCompileFileToElement(noneFileList, "None", true));
 
             var itemGroupElement = new XElement("ItemGroup", elementList);
 
             elementList = new List<XElement>();
-            elementList.AddRange(XamlItemCompileFileToElement(pageFileList, "Page", false));
+            elementList.AddRange(XamlItemCompileFileToElement(resourceFileList, $"{prefix}Resource", true));
+            elementList.AddRange(XamlItemCompileFileToElement(pageFileList, $"{prefix}Page", false));
 
             var itemGroupElementOfXaml = new XElement("ItemGroup", elementList);
 
@@ -45,6 +50,7 @@ namespace dotnetCampus.SourceYard.Utils
         private readonly PackagedProjectFile _contextPackagedProjectFile;
         private readonly string _filePath;
         private readonly bool _isVisible;
+        private readonly string _packageGuid;
 
         private List<XElement> XamlItemCompileFileToElement(List<string> compileFileList, string includingItemTypes,
             bool copyToOutputDirectory)


### PR DESCRIPTION
详细请看
[从零开始制作 NuGet 源代码包（全面支持 .NET Core / .NET Framework / WPF 项目） - walterlv](https://blog.walterlv.com/post/build-source-code-package-for-wpf-projects.html )

#35 

当前存在的一个问题是如果存在两个 xaml 文件的文件名相同，那么将会编译失败

解决方法是重命名