### PR TITLE
Internal classes and change namespace to avoid conflictions

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.16257-alpha</Version>
+    <Version>0.1.17750-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/src/dotnetCampus.SourceYard/ApplyFlow/IApplyFlow.cs
+++ b/src/dotnetCampus.SourceYard/ApplyFlow/IApplyFlow.cs
@@ -1,0 +1,9 @@
+﻿using dotnetCampus.SourceYard.Cli;
+
+namespace dotnetCampus.SourceYard.ApplyFlow
+{
+    internal interface IApplyFlow
+    {
+        void Apply(ApplyOptions options);
+    }
+}

--- a/src/dotnetCampus.SourceYard/ApplyFlow/TransformCodeFlow.cs
+++ b/src/dotnetCampus.SourceYard/ApplyFlow/TransformCodeFlow.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using dotnetCampus.SourceYard.Cli;
+using dotnetCampus.SourceYard.Context;
+
+namespace dotnetCampus.SourceYard.ApplyFlow
+{
+    /// <summary>
+    /// 进行源代码转换。
+    /// </summary>
+    internal class TransformCodeFlow : IApplyFlow
+    {
+        public void Apply(ApplyOptions options)
+        {
+            if (!options.InternalAllClasses && !options.UseLocalNamespace)
+            {
+                Console.WriteLine(options.SourceFolder);
+            }
+        }
+    }
+}

--- a/src/dotnetCampus.SourceYard/ApplyFlow/TransformCodeFlow.cs
+++ b/src/dotnetCampus.SourceYard/ApplyFlow/TransformCodeFlow.cs
@@ -15,7 +15,7 @@ namespace dotnetCampus.SourceYard.ApplyFlow
     {
         public void Apply(ApplyOptions options)
         {
-            if (!options.InternalAllClasses && !options.UseLocalNamespace)
+            if (!options.InternalAllClasses && string.IsNullOrWhiteSpace(options.LocalRootNamespace))
             {
                 Console.WriteLine(options.SourceFolder);
             }
@@ -39,11 +39,9 @@ namespace dotnetCampus.SourceYard.ApplyFlow
                 }
             }
 
-            Debugger.Launch();
-
             FileSystem.TransformFolderContents(options.SourceFolder, options.TransformedSourceFolder,
                 (file, content) => TransformCode(file, content,
-                    originalNamespace, options.RootNamespace,
+                    originalNamespace, options.LocalRootNamespace,
                     options.InternalAllClasses));
         }
 

--- a/src/dotnetCampus.SourceYard/ApplyFlow/TransformCodeFlow.cs
+++ b/src/dotnetCampus.SourceYard/ApplyFlow/TransformCodeFlow.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
+using System.Text.RegularExpressions;
 using dotnetCampus.SourceYard.Cli;
-using dotnetCampus.SourceYard.Context;
+using dotnetCampus.SourceYard.Utils;
 
 namespace dotnetCampus.SourceYard.ApplyFlow
 {
@@ -17,6 +19,74 @@ namespace dotnetCampus.SourceYard.ApplyFlow
             {
                 Console.WriteLine(options.SourceFolder);
             }
+            else
+            {
+                Console.WriteLine(options.TransformedSourceFolder);
+            }
+
+            var got = false;
+            string originalNamespace = null;
+            foreach (var line in File.ReadAllLines(options.OriginalProjectConfigs))
+            {
+                if (got)
+                {
+                    originalNamespace = line;
+                    break;
+                }
+                if (line == "RootNamespace")
+                {
+                    got = true;
+                }
+            }
+
+            Debugger.Launch();
+
+            FileSystem.TransformFolderContents(options.SourceFolder, options.TransformedSourceFolder,
+                (file, content) => TransformCode(file, content,
+                    originalNamespace, options.RootNamespace,
+                    options.InternalAllClasses));
+        }
+
+        private string TransformCode(FileInfo file, string content,
+            string originalNamespace, string rootNamespace,
+            bool internalAllClasses)
+        {
+            var ext = file.Extension;
+
+            if (_codeConverters.TryGetValue(ext, out var transformer))
+            {
+                return transformer(content, originalNamespace, rootNamespace, internalAllClasses);
+            }
+
+            return content;
+        }
+
+        private readonly Dictionary<string, Func<string, string, string, bool, string>> _codeConverters = new Dictionary<string, Func<string, string, string, bool, string>>
+        {
+            { ".cs", TransformCSharpFile },
+            { ".xaml", TransformXamlFile },
+        };
+
+        private static readonly Regex CSharpRegex = new Regex("public ((static )?(class|interface|struct|enum|delegate))", RegexOptions.Compiled);
+
+        private static string TransformCSharpFile(string content, string oldNamespace, string newNamespace, bool internalAllClasses)
+        {
+            if (internalAllClasses)
+            {
+                content = CSharpRegex.Replace(content, "internal $1");
+            }
+
+            if (!string.IsNullOrWhiteSpace(newNamespace))
+            {
+                content = content.Replace($"namespace {oldNamespace}", $"namespace {newNamespace}");
+            }
+
+            return content;
+        }
+
+        private static string TransformXamlFile(string content, string oldNamespace, string newNamespace, bool internalAllClasses)
+        {
+            return content;
         }
     }
 }

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.props
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.props
@@ -1,3 +1,6 @@
 ﻿<Project>
 
+  <!-- 如果指定为 True，那么此源代码包在安装到目标项目时，命名空间将不允许被改变。 -->
+  <SYPreventRedirectNamespace Condition=" '$(SYPreventRedirectNamespace)' == '' ">False</SYPreventRedirectNamespace>
+  
 </Project>

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.props
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.props
@@ -1,6 +1,10 @@
 ﻿<Project>
 
-  <!-- 如果指定为 True，那么此源代码包在安装到目标项目时，命名空间将不允许被改变。 -->
-  <SYPreventRedirectNamespace Condition=" '$(SYPreventRedirectNamespace)' == '' ">False</SYPreventRedirectNamespace>
+  <PropertyGroup>
+    
+    <!-- 如果指定为 True，那么此源代码包在安装到目标项目时，命名空间将不允许被改变。 -->
+    <SYPreventRedirectNamespace Condition=" '$(SYPreventRedirectNamespace)' == '' ">False</SYPreventRedirectNamespace>
+    
+  </PropertyGroup>
   
 </Project>

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -42,9 +42,8 @@
         </ItemGroup>
         <WriteLinesToFile File="$(PackageReferenceVersionFile)" Lines="@(_PackageReferenceVersion)" Overwrite="true" />
 
-        <WriteLinesToFile File="$(ConfigsRootNamespace)" Lines="$(RootNamespace)" Overwrite="true"></WriteLinesToFile>
-        <!--<WriteLinesToFile Condition=" '$(RootNamespace)' != '' " File="$(ConfigsRootNamespace)" Lines="$(RootNamespace)" Overwrite="true"></WriteLinesToFile>
-        <WriteLinesToFile Condition=" '$(RootNamespace)' == '' " File="$(ConfigsRootNamespace)" Lines="$(MSBuildProjectName)" Overwrite="true"></WriteLinesToFile>-->
+        <WriteLinesToFile Conditional=" '$(SYPreventRedirectNamespace)' == 'True' " File="$(ConfigsRootNamespace)" Lines="!" Overwrite="true"></WriteLinesToFile>
+        <WriteLinesToFile Conditional=" '$(SYPreventRedirectNamespace)' != 'True' " File="$(ConfigsRootNamespace)" Lines="$(RootNamespace)" Overwrite="true"></WriteLinesToFile>
       
         <PropertyGroup>
 

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -18,7 +18,7 @@
 
             <PackageReferenceVersionFile>$(SourcePackingDirectory)PackageReferenceVersionFile.txt</PackageReferenceVersionFile>
           
-            <SourceConfigsRootNamespace>$(SourcePackingDirectory)SourceConfigsRootNamespace.txt</SourceConfigsRootNamespace>
+            <ConfigsRootNamespace>$(SourcePackingDirectory)ConfigsRootNamespace.txt</ConfigsRootNamespace>
         </PropertyGroup>
 
         <MakeDir Condition="!Exists($(SourcePackingDirectory))" Directories="$(SourcePackingDirectory)"></MakeDir>
@@ -43,7 +43,9 @@
         <WriteLinesToFile File="$(PackageReferenceVersionFile)" Lines="@(_PackageReferenceVersion)" Overwrite="true" />
 
         <WriteLinesToFile File="$(ConfigsRootNamespace)" Lines="$(RootNamespace)" Overwrite="true"></WriteLinesToFile>
-
+        <!--<WriteLinesToFile Condition=" '$(RootNamespace)' != '' " File="$(ConfigsRootNamespace)" Lines="$(RootNamespace)" Overwrite="true"></WriteLinesToFile>
+        <WriteLinesToFile Condition=" '$(RootNamespace)' == '' " File="$(ConfigsRootNamespace)" Lines="$(MSBuildProjectName)" Overwrite="true"></WriteLinesToFile>-->
+      
         <PropertyGroup>
 
             <SourceYardAuthors Condition="$(Authors) != ''">--Authors "$(Authors)"</SourceYardAuthors>

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -17,6 +17,8 @@
             <PackageReleaseNotesFile>$(SourcePackingDirectory)PackageReleaseNotesFile.txt</PackageReleaseNotesFile>
 
             <PackageReferenceVersionFile>$(SourcePackingDirectory)PackageReferenceVersionFile.txt</PackageReferenceVersionFile>
+          
+            <SourceConfigsRootNamespace>$(SourcePackingDirectory)SourceConfigsRootNamespace.txt</SourceConfigsRootNamespace>
         </PropertyGroup>
 
         <MakeDir Condition="!Exists($(SourcePackingDirectory))" Directories="$(SourcePackingDirectory)"></MakeDir>
@@ -39,6 +41,8 @@
             </_PackageReferenceVersion>
         </ItemGroup>
         <WriteLinesToFile File="$(PackageReferenceVersionFile)" Lines="@(_PackageReferenceVersion)" Overwrite="true" />
+
+        <WriteLinesToFile File="$(ConfigsRootNamespace)" Lines="$(RootNamespace)" Overwrite="true"></WriteLinesToFile>
 
         <PropertyGroup>
 
@@ -64,11 +68,13 @@
             <SourcePackageOutputPath Condition="'$(PackageOutputPath)' != ''">-n "$(PackageOutputPath) "</SourcePackageOutputPath>
             <SourcePackageOutputPath Condition="'$(PackageOutputPath)' == '' and $(OutputPath) != ''">-n "$(OutputPath) "</SourcePackageOutputPath>
             <SourcePackageReferenceVersion>--PackageReferenceVersion $(PackageReferenceVersionFile)</SourcePackageReferenceVersion>
+
+            <SourceConfigsRootNamespace>--RootNamespace $(ConfigsRootNamespace)</SourceConfigsRootNamespace>
         </PropertyGroup>
 
 
         <Exec
-            Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion)">
+            Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) $(SourceConfigsRootNamespace)">
         </Exec>
     </Target>
 

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -76,7 +76,7 @@
 
 
         <Exec
-            Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) $(SourceConfigsRootNamespace)">
+            Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe pack $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) $(SourceConfigsRootNamespace)">
         </Exec>
     </Target>
 

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -42,8 +42,8 @@
         </ItemGroup>
         <WriteLinesToFile File="$(PackageReferenceVersionFile)" Lines="@(_PackageReferenceVersion)" Overwrite="true" />
 
-        <WriteLinesToFile Conditional=" '$(SYPreventRedirectNamespace)' == 'True' " File="$(ConfigsRootNamespace)" Lines="!" Overwrite="true"></WriteLinesToFile>
-        <WriteLinesToFile Conditional=" '$(SYPreventRedirectNamespace)' != 'True' " File="$(ConfigsRootNamespace)" Lines="$(RootNamespace)" Overwrite="true"></WriteLinesToFile>
+        <WriteLinesToFile Condition=" '$(SYPreventRedirectNamespace)' == 'True' " File="$(ConfigsRootNamespace)" Lines="!" Overwrite="true"></WriteLinesToFile>
+        <WriteLinesToFile Condition=" '$(SYPreventRedirectNamespace)' != 'True' " File="$(ConfigsRootNamespace)" Lines="$(RootNamespace)" Overwrite="true"></WriteLinesToFile>
       
         <PropertyGroup>
 

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
@@ -1,15 +1,22 @@
 ﻿<Project>
 
-    <ItemGroup>
-        <SourceReference Include="#(PackageId)" />
-    </ItemGroup>
+  <ItemGroup>
+    <SourceReference Include="#(PackageId)" />
+  </ItemGroup>
 
-    <PropertyGroup>
-        <!-- 当生成 WPF 临时项目时，不会自动 Import NuGet 中的 props 和 targets 文件，这使得在临时项目中你现在看到的整个文件都不会参与编译。
-          然而，我们可以通过欺骗的方式在主项目中通过 _GeneratedCodeFiles 集合将需要编译的文件传递到临时项目中以间接参与编译。
-          WPF 临时项目不会 Import NuGet 中的 props 和 targets 可能是 WPF 的 Bug，也可能是刻意如此。
-          所以我们通过一个属性开关 `ShouldFixNuGetImportingBugForWpfProjects` 来决定是否修复这个错误。-->
-        <ShouldFixNuGetImportingBugForWpfProjects Condition=" '$(ShouldFixNuGetImportingBugForWpfProjects)' == '' ">True</ShouldFixNuGetImportingBugForWpfProjects>
-    </PropertyGroup>
+  <PropertyGroup>
+
+    <!-- 如果设置为 True，那么源码包应用到目标项目中时，会使用目标项目命名空间前缀替代原项目的命名空间前缀。 -->
+    <SYUseLocalNamespace Condition=" '$(SYUseLocalNamespace)' == '' ">False</SYUseLocalNamespace>
+
+    <!-- 如果设置为 True，那么源码包应用到目标项目中时，会将所有类型设置为 internal 访问级别。 -->
+    <SYInternalAllClasses Condition=" '$(SYInternalAllClasses)' == '' ">False</SYInternalAllClasses>
+
+    <!-- 当生成 WPF 临时项目时，不会自动 Import NuGet 中的 props 和 targets 文件，这使得在临时项目中你现在看到的整个文件都不会参与编译。
+         然而，我们可以通过欺骗的方式在主项目中通过 _GeneratedCodeFiles 集合将需要编译的文件传递到临时项目中以间接参与编译。
+         WPF 临时项目不会 Import NuGet 中的 props 和 targets 可能是 WPF 的 Bug，也可能是刻意如此。
+         所以我们通过一个属性开关 `ShouldFixNuGetImportingBugForWpfProjects` 来决定是否修复这个错误。-->
+    <ShouldFixNuGetImportingBugForWpfProjects Condition=" '$(ShouldFixNuGetImportingBugForWpfProjects)' == '' ">True</ShouldFixNuGetImportingBugForWpfProjects>
+  </PropertyGroup>
 
 </Project>

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
@@ -6,8 +6,13 @@
 
   <PropertyGroup>
 
-    <!-- 如果设置为一个新的命名空间字符串，那么源码包应用到目标项目中时，会使用此命名空间前缀替代原项目的命名空间前缀。 -->
+    <!-- 源代码包全局命名空间设置：
+         如果设置为一个新的命名空间字符串，那么源码包应用到目标项目中时，会使用此命名空间前缀替代原项目的命名空间前缀。 -->
     <SYLocalRootNamespace Condition=" '$(SYLocalRootNamespace)' == '' "></SYLocalRootNamespace>
+
+    <!-- 单个源代码包命名空间设置（优先级高于全局）：
+         如果设置为一个新的命名空间字符串，那么源码包应用到目标项目中时，会使用此命名空间前缀替代原项目的命名空间前缀。 -->
+    <#(PackageGuid)LocalRootNamespace Condition=" '$(#(PackageGuid)LocalRootNamespace)' == '' "></#(PackageGuid)LocalRootNamespace>
 
     <!-- 如果设置为 True，那么源码包应用到目标项目中时，会将所有类型设置为 internal 访问级别。 -->
     <SYInternalAllClasses Condition=" '$(SYInternalAllClasses)' == '' ">False</SYInternalAllClasses>

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
 
-    <!-- 如果设置为 True，那么源码包应用到目标项目中时，会使用目标项目命名空间前缀替代原项目的命名空间前缀。 -->
-    <SYUseLocalNamespace Condition=" '$(SYUseLocalNamespace)' == '' ">False</SYUseLocalNamespace>
+    <!-- 如果设置为一个新的命名空间字符串，那么源码包应用到目标项目中时，会使用此命名空间前缀替代原项目的命名空间前缀。 -->
+    <SYLocalRootNamespace Condition=" '$(SYLocalRootNamespace)' == '' "></SYLocalRootNamespace>
 
     <!-- 如果设置为 True，那么源码包应用到目标项目中时，会将所有类型设置为 internal 访问级别。 -->
     <SYInternalAllClasses Condition=" '$(SYInternalAllClasses)' == '' ">False</SYInternalAllClasses>

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
@@ -14,9 +14,14 @@
          如果设置为一个新的命名空间字符串，那么源码包应用到目标项目中时，会使用此命名空间前缀替代原项目的命名空间前缀。 -->
     <#(PackageGuid)LocalRootNamespace Condition=" '$(#(PackageGuid)LocalRootNamespace)' == '' "></#(PackageGuid)LocalRootNamespace>
 
-    <!-- 如果设置为 True，那么源码包应用到目标项目中时，会将所有类型设置为 internal 访问级别。 -->
+    <!-- 源代码包全局命名空间设置：
+         如果设置为 True，那么源码包应用到目标项目中时，会将所有类型设置为 internal 访问级别。 -->
     <SYInternalAllClasses Condition=" '$(SYInternalAllClasses)' == '' ">False</SYInternalAllClasses>
 
+    <!-- 单个源代码包命名空间设置（优先级高于全局）：
+         如果设置为 True，那么源码包应用到目标项目中时，会将所有类型设置为 internal 访问级别。 -->
+    <#(PackageGuid)InternalAllClasses Condition=" '$(#(PackageGuid)InternalAllClasses)' == '' "></#(PackageGuid)InternalAllClasses>
+    
     <!-- 当生成 WPF 临时项目时，不会自动 Import NuGet 中的 props 和 targets 文件，这使得在临时项目中你现在看到的整个文件都不会参与编译。
          然而，我们可以通过欺骗的方式在主项目中通过 _GeneratedCodeFiles 集合将需要编译的文件传递到临时项目中以间接参与编译。
          WPF 临时项目不会 Import NuGet 中的 props 和 targets 可能是 WPF 的 Bug，也可能是刻意如此。

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
@@ -45,13 +45,20 @@
   <Target Name="_#(PackageGuid)PrepareAllSourceCodes" 
     Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
     <PropertyGroup>
+      <!-- 按照优先级 #(PackageGuid)LocalRootNamespace > SYLocalRootNamespace 来初始化 _SourceYardLocalRootNamespace。 -->
       <_SourceYardLocalRootNamespace Condition=" '$(#(PackageGuid)LocalRootNamespace)' == '' "></_SourceYardLocalRootNamespace>
       <_SourceYardLocalRootNamespace Condition=" '$(#(PackageGuid)LocalRootNamespace)' != '' ">$(#(PackageGuid)LocalRootNamespace)</_SourceYardLocalRootNamespace>
       <_SourceYardLocalRootNamespace Condition=" '$(_SourceYardLocalRootNamespace)' == '' And '$(SYLocalRootNamespace)' == '' ">null</_SourceYardLocalRootNamespace>
       <_SourceYardLocalRootNamespace Condition=" '$(_SourceYardLocalRootNamespace)' == '' And '$(SYLocalRootNamespace)' != '' ">$(SYLocalRootNamespace)</_SourceYardLocalRootNamespace>
-    </PropertyGroup>
+
+      <!-- 按照优先级 #(PackageGuid)InternalAllClasses > SYInternalAllClasses 来初始化 _SourceYardInternalAllClasses。 -->
+      <_SourceYardInternalAllClasses Condition=" '$(#(PackageGuid)InternalAllClasses)' == '' "></_SourceYardInternalAllClasses>
+      <_SourceYardInternalAllClasses Condition=" '$(#(PackageGuid)InternalAllClasses)' != '' ">$(#(PackageGuid)InternalAllClasses)</_SourceYardInternalAllClasses>
+      <_SourceYardInternalAllClasses Condition=" '$(_SourceYardInternalAllClasses)' == '' And '$(SYInternalAllClasses)' == '' ">False</_SourceYardInternalAllClasses>
+      <_SourceYardInternalAllClasses Condition=" '$(_SourceYardInternalAllClasses)' == '' And '$(SYInternalAllClasses)' != '' ">$(SYInternalAllClasses)</_SourceYardInternalAllClasses>
+  </PropertyGroup>
     <Exec ConsoleToMSBuild="True"
-          Command="&quot;$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe&quot; apply -s &quot;$(MSBuildThisFileDirectory)..\src&quot; -t $(IntermediateOutputPath)SourcePacking\Apply -c &quot;$(MSBuildThisFileDirectory)..\configs\Project.txt&quot; --local $(_SourceYardLocalRootNamespace) --internal $(SYInternalAllClasses)">
+          Command="&quot;$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe&quot; apply -s &quot;$(MSBuildThisFileDirectory)..\src&quot; -t $(IntermediateOutputPath)SourcePacking\Apply -c &quot;$(MSBuildThisFileDirectory)..\configs\Project.txt&quot; --local $(_SourceYardLocalRootNamespace) --internal $(_SourceYardInternalAllClasses)">
       <Output TaskParameter="ConsoleOutput" PropertyName="_#(PackageGuid)SourceFolder" />
     </Exec>
   </Target>

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
@@ -45,7 +45,7 @@
   <Target Name="_#(PackageGuid)PrepareAllSourceCodes" 
     Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
     <Exec ConsoleToMSBuild="True"
-          Command="&quot;$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe&quot; apply -s &quot;$(MSBuildThisFileDirectory)..\src&quot; -t $(IntermediateOutputPath)SourcePacking\Apply -n $(RootNamespace) --local $(SYUseLocalNamespace) --internal $(SYInternalAllClasses)">
+          Command="&quot;$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe&quot; apply -s &quot;$(MSBuildThisFileDirectory)..\src&quot; -t $(IntermediateOutputPath)SourcePacking\Apply -c &quot;$(MSBuildThisFileDirectory)..\configs\Project.txt&quot; -n $(RootNamespace) --local $(SYUseLocalNamespace) --internal $(SYInternalAllClasses)">
       <Output TaskParameter="ConsoleOutput" PropertyName="_#(PackageGuid)SourceFolder" />
     </Exec>
   </Target>

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
@@ -42,26 +42,38 @@
     <WriteLinesToFile File="$(MSBuildProjectDirectory)/SourceProject/.gitignore" Lines=".gitignore;/*.Source.SourceProject.props" Overwrite="true" />
   </Target>
 
-  <Target Name="_#(PackageGuid)IncludeSourceCodes" 
+  <Target Name="_#(PackageGuid)PrepareAllSourceCodes" 
     Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
+    <Exec ConsoleToMSBuild="True"
+          Command="&quot;$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe&quot; apply -s &quot;$(MSBuildThisFileDirectory)..\src&quot; -t $(IntermediateOutputPath)SourcePacking\Apply -n $(RootNamespace) --local $(SYUseLocalNamespace) --internal $(SYInternalAllClasses)">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_#(PackageGuid)SourceFolder" />
+    </Exec>
+  </Target>
+
+  <Target Name="_#(PackageGuid)IncludeSourceCodes" 
+    Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) "
+    DependsOnTargets="_#(PackageGuid)PrepareAllSourceCodes">
     <!-- 只有在不没有找到本地代码的文件时，才使用 nuget 的库 -->
     <!--替换ItemGroup-->
   </Target>
 
-  <Target Name="_#(PackageGuid)XamlItemGroupIncludeSourceCodes" 
-    Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
+  <Target Name="_#(PackageGuid)XamlItemGroupIncludeSourceCodes"
+    Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) "
+    DependsOnTargets="_#(PackageGuid)PrepareAllSourceCodes">
     <!-- 只有在不没有找到本地代码的文件时，才使用 nuget 的库 -->
     <!--替换XmlItemGroup-->
   </Target>
 
-  <Target Name="_#(PackageGuid)IncludeSOURCE_REFERENCESourceCodes" 
-    Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))">
+  <Target Name="_#(PackageGuid)IncludeSOURCE_REFERENCESourceCodes"
+    Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))"
+    DependsOnTargets="_#(PackageGuid)PrepareAllSourceCodes">
     <!-- 如果可以找到本地代码，就打开用户代码可以调试 -->
     <!--替换 SOURCE_REFERENCE ItemGroup-->
   </Target>
 
-  <Target Name="_#(PackageGuid)IncludeXamlItemGroupSOURCE_REFERENCESourceCodes" 
-    Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))">
+  <Target Name="_#(PackageGuid)IncludeXamlItemGroupSOURCE_REFERENCESourceCodes"
+    Condition="$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE'))"
+    DependsOnTargets="_#(PackageGuid)PrepareAllSourceCodes">
     <!-- 如果可以找到本地代码，就打开用户代码可以调试 -->
     <!--替换 SOURCE_REFERENCE XmlItemGroup-->
 

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
@@ -45,8 +45,10 @@
   <Target Name="_#(PackageGuid)PrepareAllSourceCodes" 
     Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
     <PropertyGroup>
-      <_SourceYardLocalRootNamespace Condition=" '$(SYLocalRootNamespace)' == '' ">null</_SourceYardLocalRootNamespace>
-      <_SourceYardLocalRootNamespace Condition=" '$(SYLocalRootNamespace)' != '' ">$(SYLocalRootNamespace)</_SourceYardLocalRootNamespace>
+      <_SourceYardLocalRootNamespace Condition=" '$(#(PackageGuid)LocalRootNamespace)' == '' "></_SourceYardLocalRootNamespace>
+      <_SourceYardLocalRootNamespace Condition=" '$(#(PackageGuid)LocalRootNamespace)' != '' ">$(#(PackageGuid)LocalRootNamespace)</_SourceYardLocalRootNamespace>
+      <_SourceYardLocalRootNamespace Condition=" '$(_SourceYardLocalRootNamespace)' == '' And '$(SYLocalRootNamespace)' == '' ">null</_SourceYardLocalRootNamespace>
+      <_SourceYardLocalRootNamespace Condition=" '$(_SourceYardLocalRootNamespace)' == '' And '$(SYLocalRootNamespace)' != '' ">$(SYLocalRootNamespace)</_SourceYardLocalRootNamespace>
     </PropertyGroup>
     <Exec ConsoleToMSBuild="True"
           Command="&quot;$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe&quot; apply -s &quot;$(MSBuildThisFileDirectory)..\src&quot; -t $(IntermediateOutputPath)SourcePacking\Apply -c &quot;$(MSBuildThisFileDirectory)..\configs\Project.txt&quot; --local $(_SourceYardLocalRootNamespace) --internal $(SYInternalAllClasses)">

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).targets
@@ -44,8 +44,12 @@
 
   <Target Name="_#(PackageGuid)PrepareAllSourceCodes" 
     Condition="!$(DefineConstants.Contains('#(PackageGuid)SOURCE_REFERENCE')) ">
+    <PropertyGroup>
+      <_SourceYardLocalRootNamespace Condition=" '$(SYLocalRootNamespace)' == '' ">null</_SourceYardLocalRootNamespace>
+      <_SourceYardLocalRootNamespace Condition=" '$(SYLocalRootNamespace)' != '' ">$(SYLocalRootNamespace)</_SourceYardLocalRootNamespace>
+    </PropertyGroup>
     <Exec ConsoleToMSBuild="True"
-          Command="&quot;$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe&quot; apply -s &quot;$(MSBuildThisFileDirectory)..\src&quot; -t $(IntermediateOutputPath)SourcePacking\Apply -c &quot;$(MSBuildThisFileDirectory)..\configs\Project.txt&quot; -n $(RootNamespace) --local $(SYUseLocalNamespace) --internal $(SYInternalAllClasses)">
+          Command="&quot;$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe&quot; apply -s &quot;$(MSBuildThisFileDirectory)..\src&quot; -t $(IntermediateOutputPath)SourcePacking\Apply -c &quot;$(MSBuildThisFileDirectory)..\configs\Project.txt&quot; --local $(_SourceYardLocalRootNamespace) --internal $(SYInternalAllClasses)">
       <Output TaskParameter="ConsoleOutput" PropertyName="_#(PackageGuid)SourceFolder" />
     </Exec>
   </Target>

--- a/src/dotnetCampus.SourceYard/Cli/ApplyOptions.cs
+++ b/src/dotnetCampus.SourceYard/Cli/ApplyOptions.cs
@@ -29,22 +29,16 @@ namespace dotnetCampus.SourceYard.Cli
         public string OriginalProjectConfigs { get; set; }
 
         /// <summary>
-        /// 目标项目的根命名空间
-        /// </summary>
-        [Option('n', "namespace", Required = true)]
-        public string RootNamespace { get; set; }
-
-        /// <summary>
         /// 是否需要将命名空间修改为本地命名空间。
         /// </summary>
         [Option("local", Required = true)]
-        public string UseLocalNamespaceCore
+        public string LocalRootNamespaceCore
         {
-            get => UseLocalNamespace.ToString();
-            set => UseLocalNamespace = value?.Equals("true", StringComparison.OrdinalIgnoreCase) is true;
+            get => LocalRootNamespace;
+            set => LocalRootNamespace = value?.Equals("null", StringComparison.OrdinalIgnoreCase) == false ? value : null;
         }
 
-        public bool UseLocalNamespace { get; private set; }
+        public string LocalRootNamespace { get; private set; }
 
         /// <summary>
         /// 是否需要将所有的类型改为 internal。

--- a/src/dotnetCampus.SourceYard/Cli/ApplyOptions.cs
+++ b/src/dotnetCampus.SourceYard/Cli/ApplyOptions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+
+namespace dotnetCampus.SourceYard.Cli
+{
+    [Verb("apply")]
+    class ApplyOptions
+    {
+        /// <summary>
+        /// 源代码所在的路径
+        /// </summary>
+        [Option('s', "source", Required = true)]
+        public string SourceFolder { get; set; }
+
+        /// <summary>
+        /// 转换后的源代码所在的路径
+        /// </summary>
+        [Option('t', "transform", Required = true)]
+        public string TransformedSourceFolder { get; set; }
+
+        /// <summary>
+        /// 目标项目的根命名空间
+        /// </summary>
+        [Option('n', "namespace", Required = true)]
+        public string RootNamespace { get; set; }
+
+        /// <summary>
+        /// 是否需要将命名空间修改为本地命名空间。
+        /// </summary>
+        [Option("local", Required = true)]
+        public string UseLocalNamespaceCore
+        {
+            get => UseLocalNamespace.ToString();
+            set => UseLocalNamespace = value?.Equals("true", StringComparison.OrdinalIgnoreCase) is true;
+        }
+
+        public bool UseLocalNamespace { get; private set; }
+
+        /// <summary>
+        /// 是否需要将所有的类型改为 internal。
+        /// </summary>
+        [Option("internal", Required = true)]
+        public string InternalAllClassesCore
+        {
+            get => InternalAllClasses.ToString();
+            set => InternalAllClasses = value?.Equals("true", StringComparison.OrdinalIgnoreCase) is true;
+        }
+
+        /// <summary>
+        /// 是否需要将所有的类型改为 internal。
+        /// </summary>
+        public bool InternalAllClasses { get; private set; }
+    }
+}

--- a/src/dotnetCampus.SourceYard/Cli/ApplyOptions.cs
+++ b/src/dotnetCampus.SourceYard/Cli/ApplyOptions.cs
@@ -23,6 +23,12 @@ namespace dotnetCampus.SourceYard.Cli
         public string TransformedSourceFolder { get; set; }
 
         /// <summary>
+        /// 源项目中已经存储的部分配置
+        /// </summary>
+        [Option('c', "configs", Required = true)]
+        public string OriginalProjectConfigs { get; set; }
+
+        /// <summary>
         /// 目标项目的根命名空间
         /// </summary>
         [Option('n', "namespace", Required = true)]

--- a/src/dotnetCampus.SourceYard/Cli/Options.cs
+++ b/src/dotnetCampus.SourceYard/Cli/Options.cs
@@ -109,5 +109,11 @@ namespace dotnetCampus.SourceYard.Cli
 
         [Option(longName: "PackageReferenceVersion")]
         public string PackageReferenceVersion { get; set; }
+
+        /// <summary>
+        /// 项目的根命名空间
+        /// </summary>
+        [Option(longName: "RootNamespace")]
+        public string RootNamespace { get; set; }
     }
 }

--- a/src/dotnetCampus.SourceYard/Cli/PackOptions.cs
+++ b/src/dotnetCampus.SourceYard/Cli/PackOptions.cs
@@ -3,7 +3,8 @@ using CommandLine;
 
 namespace dotnetCampus.SourceYard.Cli
 {
-    internal class Options
+    [Verb("pack")]
+    internal class PackOptions
     {
         /// <summary>
         /// 项目文件所在的路径

--- a/src/dotnetCampus.SourceYard/Context/IPackingContext.cs
+++ b/src/dotnetCampus.SourceYard/Context/IPackingContext.cs
@@ -59,5 +59,6 @@ namespace dotnetCampus.SourceYard.Context
 
         BuildProps BuildProps { get; }
         string PackageReferenceVersion { get; }
+        string RootNamespace { get; }
     }
 }

--- a/src/dotnetCampus.SourceYard/Context/PackingContext.cs
+++ b/src/dotnetCampus.SourceYard/Context/PackingContext.cs
@@ -8,7 +8,8 @@ namespace dotnetCampus.SourceYard.Context
     {
         public PackingContext(ILogger logger, string projectFile,
             string projectName, string packageId, string packageVersion, string packageOutputPath, string packingFolder,
-            PackagedProjectFile packagedProjectFile, string packageReferenceVersion)
+            PackagedProjectFile packagedProjectFile, string packageReferenceVersion,
+            string rootNamespace)
         {
             Logger = logger;
           
@@ -31,6 +32,7 @@ namespace dotnetCampus.SourceYard.Context
             PackageReferenceVersion = packageReferenceVersion;
             PackageVersion = packageVersion;
             PackageOutputPath = packageOutputPath;
+            RootNamespace = rootNamespace;
         }
 
         /// <inheritdoc />
@@ -64,5 +66,7 @@ namespace dotnetCampus.SourceYard.Context
         public string PackageReferenceVersion { get; }
 
         public BuildProps BuildProps { get; set; }
+
+        public string RootNamespace { get; }
     }
 }

--- a/src/dotnetCampus.SourceYard/PackFlow/AssetsPacker.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/AssetsPacker.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Text;
 using dotnetCampus.SourceYard.Context;
 using dotnetCampus.SourceYard.Utils;
 
@@ -18,17 +17,6 @@ namespace dotnetCampus.SourceYard.PackFlow
             var copyFolder = Path.Combine(context.PackingFolder, "build");
             FileSystem.CopyFolderContents(assetsFolder, copyFolder, name =>
                 name.Replace("$(PackageId)", context.PackageId));
-
-            // 替换 props 和 targets 文件中的占位符。
-            foreach (var file in new DirectoryInfo(copyFolder)
-                .EnumerateFiles("*.*", SearchOption.AllDirectories))
-            {
-                var builder = new StringBuilder(File.ReadAllText(file.FullName, Encoding.UTF8));
-                builder
-                    .Replace("#(PackageId)", context.PackageId)
-                    .Replace("#(PackageGuid)", context.PackageGuid);
-                File.WriteAllText(file.FullName, builder.ToString(), Encoding.UTF8);
-            }
         }
     }
 }

--- a/src/dotnetCampus.SourceYard/PackFlow/EvaluatePacker.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/EvaluatePacker.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+using System.Text;
+using dotnetCampus.SourceYard.Context;
+
+namespace dotnetCampus.SourceYard.PackFlow
+{
+    internal class EvaluatePacker : IPackFlow
+    {
+        public void Pack(IPackingContext context)
+        {
+            var copyFolder = Path.Combine(context.PackingFolder, "build");
+
+            // 替换 props 和 targets 文件中的占位符。
+            foreach (var file in new DirectoryInfo(copyFolder)
+                .EnumerateFiles("*.*", SearchOption.AllDirectories))
+            {
+                var builder = new StringBuilder(File.ReadAllText(file.FullName, Encoding.UTF8));
+                builder
+                    .Replace("#(PackageId)", context.PackageId)
+                    .Replace("#(PackageGuid)", context.PackageGuid);
+                File.WriteAllText(file.FullName, builder.ToString(), Encoding.UTF8);
+            }
+        }
+    }
+}

--- a/src/dotnetCampus.SourceYard/PackFlow/ItemGroupPacker.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/ItemGroupPacker.cs
@@ -38,7 +38,7 @@ namespace dotnetCampus.SourceYard.PackFlow
             // 从原始的项目文件中提取所有的 ItemGroup 中的节点，且节点类型在 IncludingItemTypes 中。
 
             // nuget 的源代码
-            var sourceReferenceSourceFolder = @"$(MSBuildThisFileDirectory)..\src\";
+            var sourceReferenceSourceFolder = @"$(_#(PackageGuid)SourceFolder)\";
 
             // 读取文件
             var buildfile = File.ReadAllText(buildAssetsFile);

--- a/src/dotnetCampus.SourceYard/PackFlow/ProjectPropertiesGenerator.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/ProjectPropertiesGenerator.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using dotnetCampus.SourceYard.Context;
+
+namespace dotnetCampus.SourceYard.PackFlow
+{
+    /// <summary>
+    /// 将源项目的一些属性存起来，这样可以在目标项目中使用。
+    /// </summary>
+    internal class ProjectPropertiesGenerator : IPackFlow
+    {
+        public void Pack(IPackingContext context)
+        {
+            // 生成源项目的属性。
+        }
+    }
+}

--- a/src/dotnetCampus.SourceYard/PackFlow/ProjectPropertiesGenerator.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/ProjectPropertiesGenerator.cs
@@ -17,7 +17,7 @@ namespace dotnetCampus.SourceYard.PackFlow
             var configsFile = Path.Combine(configsFolder, "Project.txt");
             var configsContent = $@">
 RootNamespace
-{context.RootNamespace}
+{File.ReadAllText(context.RootNamespace)}
 >";
 
             const int retryCount = 10;

--- a/src/dotnetCampus.SourceYard/PackFlow/ProjectPropertiesGenerator.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/ProjectPropertiesGenerator.cs
@@ -12,7 +12,30 @@ namespace dotnetCampus.SourceYard.PackFlow
     {
         public void Pack(IPackingContext context)
         {
-            // 生成源项目的属性。
+            var configsFolder = Path.Combine(context.PackingFolder, "configs");
+            Directory.CreateDirectory(configsFolder);
+            var configsFile = Path.Combine(configsFolder, "Project.txt");
+            var configsContent = $@">
+RootNamespace
+{context.RootNamespace}
+>";
+
+            const int retryCount = 10;
+            for (int i = 0; i < retryCount; i++)
+            {
+                try
+                {
+                    File.WriteAllText(configsFile, configsContent);
+                    break;
+                }
+                catch (IOException)
+                {
+                    if (i == retryCount - 1)
+                    {
+                        throw;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/dotnetCampus.SourceYard/PackFlow/SelfPacker.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/SelfPacker.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using dotnetCampus.SourceYard.Context;
+using dotnetCampus.SourceYard.Utils;
+
+namespace dotnetCampus.SourceYard.PackFlow
+{
+    internal class SelfPacker : IPackFlow
+    {
+        public void Pack(IPackingContext context)
+        {
+            var current = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            while (current != null && !current.Name.Equals("tools", StringComparison.OrdinalIgnoreCase))
+            {
+                current = current.Parent;
+            }
+            if (current is null)
+            {
+                return;
+            }
+
+            MoveFolder(current.FullName, context.PackingFolder);
+        }
+
+        public string MoveFolder(string source, string targetFolder)
+        {
+            var sourceFolder = new DirectoryInfo(source);
+
+            Log("开始移动文件夹");
+
+            var installFolder = Path.Combine(targetFolder, sourceFolder.Name);
+            try
+            {
+                if (Directory.Exists(installFolder))
+                {
+                    Log("发现" + installFolder + "存在，开始删除文件");
+                    DeleteDirectory(installFolder);
+                    Log("自动更新插件删除文件成功");
+                }
+            }
+            catch (Exception e)
+            {
+                Log(e.ToString());
+            }
+
+            try
+            {
+                if (Path.GetPathRoot(sourceFolder.FullName) == Path.GetPathRoot(installFolder))
+                {
+                    Log("在相同驱动器，移动文件到安装");
+                    Directory.CreateDirectory(Path.GetDirectoryName(installFolder));
+                    Directory.Move(sourceFolder.FullName, installFolder);
+                }
+                else
+                {
+                    Log("在不相同驱动器，使用复制文件到安装");
+                    DirectoryCopy(sourceFolder, installFolder);
+                }
+            }
+            catch (Exception e)
+            {
+                Log(e.ToString());
+            }
+
+            return installFolder;
+        }
+
+        private void DirectoryCopy(DirectoryInfo sourceDirectory, string destDirName)
+        {
+            Log($"从{sourceDirectory.FullName}复制到{destDirName}");
+
+            // Get the subdirectories for the specified directory.
+
+            if (!sourceDirectory.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    "Source directory does not exist or could not be found: "
+                    + sourceDirectory.FullName);
+            }
+
+            DirectoryInfo[] dirs = sourceDirectory.GetDirectories();
+            // If the destination directory doesn't exist, create it.
+            if (!Directory.Exists(destDirName))
+            {
+                Directory.CreateDirectory(destDirName);
+            }
+
+            // Get the files in the directory and copy them to the new location.
+            FileInfo[] files = sourceDirectory.GetFiles();
+            foreach (FileInfo file in files)
+            {
+                string tempPath = Path.Combine(destDirName, file.Name);
+                file.CopyTo(tempPath, false);
+            }
+
+            // If copying subdirectories, copy them and their contents to new location.
+
+            foreach (DirectoryInfo temp in dirs)
+            {
+                string tempPath = Path.Combine(destDirName, temp.Name);
+                DirectoryCopy(temp, tempPath);
+            }
+        }
+
+        private static void DeleteDirectory(string directory)
+        {
+            DeleteDirectory(directory, 0);
+
+            void DeleteDirectory(string d, int depth)
+            {
+                if (!Directory.Exists(d))
+                {
+                    return;
+                }
+
+                var sourceFolder = new DirectoryInfo(d);
+                foreach (var fileInfo in sourceFolder.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
+                {
+                    File.Delete(fileInfo.FullName);
+                }
+
+                foreach (var directoryInfo in sourceFolder.EnumerateDirectories("*", SearchOption.TopDirectoryOnly))
+                {
+                    var back = string.Join("\\", Enumerable.Repeat("..", depth));
+                    DeleteDirectory(directoryInfo.FullName, depth + 1);
+                }
+
+                Directory.Delete(d);
+            }
+        }
+
+        private void Log(string _)
+        {
+        }
+    }
+}

--- a/src/dotnetCampus.SourceYard/PackFlow/SelfPacker.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/SelfPacker.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Xml;
-using System.Xml.Linq;
-using System.Xml.XPath;
 using dotnetCampus.SourceYard.Context;
 using dotnetCampus.SourceYard.Utils;
 
@@ -26,118 +20,7 @@ namespace dotnetCampus.SourceYard.PackFlow
                 return;
             }
 
-            MoveFolder(current.FullName, context.PackingFolder);
-        }
-
-        public string MoveFolder(string source, string targetFolder)
-        {
-            var sourceFolder = new DirectoryInfo(source);
-
-            Log("开始移动文件夹");
-
-            var installFolder = Path.Combine(targetFolder, sourceFolder.Name);
-            try
-            {
-                if (Directory.Exists(installFolder))
-                {
-                    Log("发现" + installFolder + "存在，开始删除文件");
-                    DeleteDirectory(installFolder);
-                    Log("自动更新插件删除文件成功");
-                }
-            }
-            catch (Exception e)
-            {
-                Log(e.ToString());
-            }
-
-            try
-            {
-                if (Path.GetPathRoot(sourceFolder.FullName) == Path.GetPathRoot(installFolder))
-                {
-                    Log("在相同驱动器，移动文件到安装");
-                    Directory.CreateDirectory(Path.GetDirectoryName(installFolder));
-                    Directory.Move(sourceFolder.FullName, installFolder);
-                }
-                else
-                {
-                    Log("在不相同驱动器，使用复制文件到安装");
-                    DirectoryCopy(sourceFolder, installFolder);
-                }
-            }
-            catch (Exception e)
-            {
-                Log(e.ToString());
-            }
-
-            return installFolder;
-        }
-
-        private void DirectoryCopy(DirectoryInfo sourceDirectory, string destDirName)
-        {
-            Log($"从{sourceDirectory.FullName}复制到{destDirName}");
-
-            // Get the subdirectories for the specified directory.
-
-            if (!sourceDirectory.Exists)
-            {
-                throw new DirectoryNotFoundException(
-                    "Source directory does not exist or could not be found: "
-                    + sourceDirectory.FullName);
-            }
-
-            DirectoryInfo[] dirs = sourceDirectory.GetDirectories();
-            // If the destination directory doesn't exist, create it.
-            if (!Directory.Exists(destDirName))
-            {
-                Directory.CreateDirectory(destDirName);
-            }
-
-            // Get the files in the directory and copy them to the new location.
-            FileInfo[] files = sourceDirectory.GetFiles();
-            foreach (FileInfo file in files)
-            {
-                string tempPath = Path.Combine(destDirName, file.Name);
-                file.CopyTo(tempPath, false);
-            }
-
-            // If copying subdirectories, copy them and their contents to new location.
-
-            foreach (DirectoryInfo temp in dirs)
-            {
-                string tempPath = Path.Combine(destDirName, temp.Name);
-                DirectoryCopy(temp, tempPath);
-            }
-        }
-
-        private static void DeleteDirectory(string directory)
-        {
-            DeleteDirectory(directory, 0);
-
-            void DeleteDirectory(string d, int depth)
-            {
-                if (!Directory.Exists(d))
-                {
-                    return;
-                }
-
-                var sourceFolder = new DirectoryInfo(d);
-                foreach (var fileInfo in sourceFolder.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
-                {
-                    File.Delete(fileInfo.FullName);
-                }
-
-                foreach (var directoryInfo in sourceFolder.EnumerateDirectories("*", SearchOption.TopDirectoryOnly))
-                {
-                    var back = string.Join("\\", Enumerable.Repeat("..", depth));
-                    DeleteDirectory(directoryInfo.FullName, depth + 1);
-                }
-
-                Directory.Delete(d);
-            }
-        }
-
-        private void Log(string _)
-        {
+            FileSystem.CopyFolderContents(current.FullName, Path.Combine(context.PackingFolder, "tools"));
         }
     }
 }

--- a/src/dotnetCampus.SourceYard/Packer.cs
+++ b/src/dotnetCampus.SourceYard/Packer.cs
@@ -12,7 +12,8 @@ namespace dotnetCampus.SourceYard
         public Packer(string projectFile, string intermediateDirectory,
             string packageOutputPath, string packageVersion, string compileFile, string resourceFile,
             string contentFile, string page, string applicationDefinition, string noneFile, string embeddedResource,
-            BuildProps buildProps, string packageId, string packageReferenceVersion)
+            BuildProps buildProps, string packageId, string packageReferenceVersion,
+            string rootNamespace)
         {
             Logger = new Logger();
 
@@ -50,6 +51,7 @@ namespace dotnetCampus.SourceYard
             _packageReferenceVersion = Path.GetFullPath(packageReferenceVersion);
             BuildProps = buildProps;
             PackageId = packageId;
+            _rootNamespace = rootNamespace;
 
             PackagedProjectFile = new PackagedProjectFile
             (
@@ -124,7 +126,8 @@ namespace dotnetCampus.SourceYard
                         _packageOutputPath,
                         packingFolder,
                         PackagedProjectFile,
-                        _packageReferenceVersion
+                        _packageReferenceVersion,
+                        _rootNamespace
                     )
                     {
                         BuildProps = buildProps,
@@ -158,6 +161,7 @@ namespace dotnetCampus.SourceYard
         private readonly string _packageVersion;
         private readonly string _packageReferenceVersion;
         private readonly IPackFlow[] _packers;
+        private readonly string _rootNamespace;
 
         private PackagedProjectFile PackagedProjectFile { get; }
         private BuildProps BuildProps { get; }

--- a/src/dotnetCampus.SourceYard/Packer.cs
+++ b/src/dotnetCampus.SourceYard/Packer.cs
@@ -66,6 +66,7 @@ namespace dotnetCampus.SourceYard
 
             _packers = new IPackFlow[]
             {
+                new SelfPacker(),
                 new SourcePacker(),
                 new AssetsPacker(),
                 new ItemGroupPacker(),

--- a/src/dotnetCampus.SourceYard/Packer.cs
+++ b/src/dotnetCampus.SourceYard/Packer.cs
@@ -71,6 +71,7 @@ namespace dotnetCampus.SourceYard
                 new AssetsPacker(),
                 new ItemGroupPacker(),
                 new ProjectPropertiesGenerator(),
+                new EvaluatePacker(),
                 new NuspecFileGenerator(),
                 new NuGetPacker(),
             };

--- a/src/dotnetCampus.SourceYard/Packer.cs
+++ b/src/dotnetCampus.SourceYard/Packer.cs
@@ -69,6 +69,7 @@ namespace dotnetCampus.SourceYard
                 new SourcePacker(),
                 new AssetsPacker(),
                 new ItemGroupPacker(),
+                new ProjectPropertiesGenerator(),
                 new NuspecFileGenerator(),
                 new NuGetPacker(),
             };

--- a/src/dotnetCampus.SourceYard/Program.cs
+++ b/src/dotnetCampus.SourceYard/Program.cs
@@ -76,7 +76,8 @@ namespace dotnetCampus.SourceYard
                     embeddedResource: options.EmbeddedResource,
                     packageId: options.PackageId,
                     buildProps: buildProps,
-                    packageReferenceVersion: options.PackageReferenceVersion).Pack();
+                    packageReferenceVersion: options.PackageReferenceVersion,
+                    rootNamespace: options.RootNamespace).Pack();
             }
             catch (Exception e)
             {

--- a/src/dotnetCampus.SourceYard/Program.cs
+++ b/src/dotnetCampus.SourceYard/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using CommandLine;
+using dotnetCampus.SourceYard.ApplyFlow;
 using dotnetCampus.SourceYard.Cli;
 using dotnetCampus.SourceYard.Utils;
 
@@ -12,12 +13,14 @@ namespace dotnetCampus.SourceYard
     {
         private static void Main(string[] args)
         {
-            Parser.Default.ParseArguments<Options>(args)
-                .WithParsed(RunOptionsAndReturnExitCode)
-                .WithNotParsed(HandleParseError);
+            Parser.Default.ParseArguments<PackOptions, ApplyOptions>(args)
+                .MapResult(
+                    (PackOptions o) => RunOptionsAndReturnExitCode(o),
+                    (ApplyOptions o) => ApplyAndReturnExitCode(o),
+                    e => HandleParseError(e));
         }
 
-        private static void RunOptionsAndReturnExitCode(Options options)
+        private static int RunOptionsAndReturnExitCode(PackOptions options)
         {
 #if DEBUG
             Debugger.Launch();
@@ -84,6 +87,8 @@ namespace dotnetCampus.SourceYard
                 logger.Error(e.Message);
             }
 
+            return 0;
+
             string ReadFile(string file)
             {
                 if (string.IsNullOrEmpty(file))
@@ -108,13 +113,20 @@ namespace dotnetCampus.SourceYard
             }
         }
 
-        private static void HandleParseError(IEnumerable<Error> errors)
+        private static int ApplyAndReturnExitCode(ApplyOptions options)
+        {
+            new TransformCodeFlow().Apply(options);
+            return 0;
+        }
+
+        private static int HandleParseError(IEnumerable<Error> errors)
         {
             var logger = new Logger();
             foreach (var temp in errors)
             {
                 logger.Error(temp.ToString());
             }
+            return 0;
         }
     }
 }

--- a/src/dotnetCampus.SourceYard/dotnetCampus.SourceYard.csproj
+++ b/src/dotnetCampus.SourceYard/dotnetCampus.SourceYard.csproj
@@ -51,7 +51,7 @@
     <!--指定自己的在安装 nuget 时修改编译-->
     <None Include="Assets\Current\**" Pack="True" PackagePath="build\" />
     <None Include="Assets\README.md" Pack="True" PackagePath="" />
-    <None Include="$(OutputPath)**\**" Pack="True" PackagePath="tools\" Visible="false"/>
+    <None Include="$(OutputPath)**\**" Pack="True" PackagePath="tools\" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. 提供属性设置 `SYInternalAllClasses` 可以将所有的类型变成 `internal`，避免被引用时导致的类型冲突；
    - 如果你就是使用源代码包提供 API，就保持默认值 `False`
    - 如果你使用源代码包仅仅为了辅助你的库实现某些复杂功能，而不打算将源代码包带的类型作为 API 对外提供，则设置为 `True`
2. 提供属性设置 `SYLocalRootNamespace` 可以修改源代码包中携带源代码的命名空间，避免被引用时导致的类型冲突；
    - 如果你就是使用源代码包提供 API，可以考虑设置一个自己期望的命名空间，如 `Walterlv.Demo.Utils`（注意，被保护的命名空间无法被设置更改）
    - 如果你使用源代码包仅仅为了辅助你的库实现某些复杂功能，则可以留空
3. 提供单个源代码包用于覆盖全局的 `SYLocalRootNamespace` 属性，如 `WalterlvDemoLocalRootNamespace`，其优先级高于全局属性。
4. 为了保护知识产权，打源代码包的项目可以通过指定 `SYPreventRedirectNamespace` 属性为 `True` 来阻止以上属性生效。

```xml
<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">

  <PropertyGroup>
    <TargetFramework>net48</TargetFramework>
    <RootNamespace>Cvte.EasiPlugins</RootNamespace>
    
    <!-- 全局将所有未被保护的源代码包的命名空间设置成自己项目默认的根命名空间。 -->
    <SYLocalRootNamespace>$(RootNamespace)</SYLocalRootNamespace>

    <!-- 单独将 Walterlv.Windows 源代码包的命名空间设置成 dotnetCampus.Windows。 -->
    <WalterlvWindowsLocalRootNamespace>dotnetCampus.Windows</WalterlvWindowsLocalRootNamespace>
    
    <!-- 将所有从源代码包引入的公共类型的访问修饰符改为 internal。 -->
    <SYInternalAllClasses>True</SYInternalAllClasses>

    <!-- 单独将 Walterlv.Windows 源代码包引入的公共类型的访问修饰符改为 internal。 -->
    <WalterlvWindowsInternalAllClasses>True</WalterlvWindowsInternalAllClasses>

  </PropertyGroup>

</Project>
```