### PR TITLE
将打包放在创建 NuGet 包，解决多个项目框架时每个框架都会创建一次包

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.17751-alpha</Version>
+    <Version>0.1.17753-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -27,6 +27,7 @@
             <PackageReleaseNotesFile>$(SourcePackingDirectory)PackageReleaseNotesFile.txt</PackageReleaseNotesFile>
 
             <PackageReferenceVersionFile>$(SourcePackingDirectory)PackageReferenceVersionFile.txt</PackageReferenceVersionFile>
+			<SourceProjectPackageFile>$(SourcePackingDirectory)SourceProjectPackageFile.txt</SourceProjectPackageFile>
         </PropertyGroup>
 
         <MakeDir Condition="!Exists($(SourcePackingDirectory))" Directories="$(SourcePackingDirectory)"></MakeDir>
@@ -43,7 +44,15 @@
         <WriteLinesToFile File="$(CopyrightFile)" Lines="$(Copyright)" Overwrite="true"></WriteLinesToFile>
         <WriteLinesToFile File="$(PackageReleaseNotesFile)" Lines="$(PackageReleaseNotes)" Overwrite="true"></WriteLinesToFile>
 
-        <ItemGroup>
+		<!-- 写入通用的信息 -->
+        <!-- 多段写入之前需要先删除文件 -->
+		<Delete Files="$(SourceProjectPackageFile)" Condition="Exists($(SourceProjectPackageFile))"></Delete>
+		<!-- 先写入RepositoryType的值，解析时将会根据此值顺序解析 -->
+		<WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;RepositoryType;$(RepositoryType);"></WriteLinesToFile>
+		<WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;PackageProjectUrl;$(PackageProjectUrl);"></WriteLinesToFile>
+		<WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;RepositoryUrl;$(RepositoryUrl);"></WriteLinesToFile>
+
+		<ItemGroup>
             <_PackageReferenceVersion
                 Include="Name='%(PackageReference.Identity)' Version='%(PackageReference.Version)' PrivateAssets='%(PackageReference.PrivateAssets)'">
             </_PackageReferenceVersion>
@@ -53,17 +62,20 @@
         <PropertyGroup>
 
             <SourceYardAuthors Condition="$(Authors) != ''">--Authors "$(Authors)"</SourceYardAuthors>
-            <SourceYardRepositoryUrl Condition="$(RepositoryUrl) != ''">--RepositoryUrl "$(RepositoryUrl)"</SourceYardRepositoryUrl>
-            <SourceYardRepositoryType Condition="$(RepositoryType) != ''">--RepositoryType "$(RepositoryType)"</SourceYardRepositoryType>
-            <SourceYardPackageProjectUrl Condition="$(PackageProjectUrl) != ''">--PackageProjectUrl "$(PackageProjectUrl)"</SourceYardPackageProjectUrl>
-            <SourceYardCopyright Condition="$(Copyright) != ''">--CopyrightFile "$(CopyrightFile)"</SourceYardCopyright>
+           
+	        <!-- 这部分长度太长会让命令行无法输入
+			<SourceYardRepositoryUrl Condition="$(RepositoryUrl) != ''">RepositoryUrl "$(RepositoryUrl)"</SourceYardRepositoryUrl>
+            <SourceYardRepositoryType Condition="$(RepositoryType) != ''">RepositoryType "$(RepositoryType)"</SourceYardRepositoryType>
+            <SourceYardPackageProjectUrl Condition="$(PackageProjectUrl) != ''">PackageProjectUrl "$(PackageProjectUrl)"</SourceYardPackageProjectUrl>-->
+			<SourceYardPackageLicenseUrl Condition="$(PackageLicenseUrl) != ''">--PackageLicenseUrl "$(PackageLicenseUrl) "</SourceYardPackageLicenseUrl>
+
+			<SourceYardCopyright Condition="$(Copyright) != ''">--CopyrightFile "$(CopyrightFile)"</SourceYardCopyright>
 
             <SourceYardPackageVersion Condition="$(PackageVersion) != ''">-v $(PackageVersion)</SourceYardPackageVersion>
 
             <SourceYardDescription Condition="$(Description) != ''">--DescriptionFile "$(DescriptionFile) "</SourceYardDescription>
 
             <SourceYardTitle Condition="$(Title) != ''">--Title "$(Title)"</SourceYardTitle>
-            <SourceYardPackageLicenseUrl Condition="$(PackageLicenseUrl) != ''">--PackageLicenseUrl "$(PackageLicenseUrl) "</SourceYardPackageLicenseUrl>
             <SourceYardOwner Condition="$(Owner) != ''">--Owner "$(Owner)"</SourceYardOwner>
             <SourceYardPackageTags Condition="$(PackageTags) != ''">--PackageTags "$(PackageTags) "</SourceYardPackageTags>
             <SourceYardPackageReleaseNotes Condition="$(PackageReleaseNotes) != ''"> --PackageReleaseNotesFile $(PackageReleaseNotesFile)</SourceYardPackageReleaseNotes>
@@ -74,11 +86,12 @@
             <SourcePackageOutputPath Condition="'$(PackageOutputPath)' != ''">-n "$(PackageOutputPath) "</SourcePackageOutputPath>
             <SourcePackageOutputPath Condition="'$(PackageOutputPath)' == '' and $(OutputPath) != ''">-n "$(OutputPath) "</SourcePackageOutputPath>
             <SourcePackageReferenceVersion>--PackageReferenceVersion $(PackageReferenceVersionFile)</SourcePackageReferenceVersion>
+
         </PropertyGroup>
 
 
         <Exec
-            Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion)">
+            Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) --SourcePackingDirectory $(SourcePackingDirectory)">
         </Exec>
     </Target>
 

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -9,7 +9,7 @@
         <Message Text="避免 SourceYard 依赖传递导致目标项目也打出源代码包" />
     </Target>
      
-    <Target Name="SourceYard" AfterTargets="AfterBuild"
+    <Target Name="SourceYard" AfterTargets="GenerateNuspec"
             Condition="$(PackSource) != 'False'">
         <PropertyGroup>
             <SourcePackingDirectory>$(IntermediateOutputPath)SourcePacking\</SourcePackingDirectory>

--- a/src/dotnetCampus.SourceYard/Cli/Options.cs
+++ b/src/dotnetCampus.SourceYard/Cli/Options.cs
@@ -65,14 +65,15 @@ namespace dotnetCampus.SourceYard.Cli
         [Option(longName: "Authors")]
         public string Authors { get; set; }
 
-        [Option(longName: "RepositoryUrl")]
-        public string RepositoryUrl { get; set; }
+        // 内容放在 SourceProjectPackageFile 文件
+        //[Option(longName: "RepositoryUrl")]
+        //public string RepositoryUrl { get; set; }
 
-        [Option(longName: "RepositoryType")]
-        public string RepositoryType { get; set; }
+        //[Option(longName: "RepositoryType")]
+        //public string RepositoryType { get; set; }
 
-        [Option(longName: "PackageProjectUrl")]
-        public string PackageProjectUrl { get; set; }
+        //[Option(longName: "PackageProjectUrl")]
+        //public string PackageProjectUrl { get; set; }
 
         /// <summary>
         /// 因为 Copyright 可能很长，有空格，写文件
@@ -109,5 +110,11 @@ namespace dotnetCampus.SourceYard.Cli
 
         [Option(longName: "PackageReferenceVersion")]
         public string PackageReferenceVersion { get; set; }
+
+        /// <summary>
+        /// 打包用到的文件夹
+        /// </summary>
+        [Option(longName: "SourcePackingDirectory")]
+        public string SourcePackingDirectory { get; set; }
     }
 }

--- a/src/dotnetCampus.SourceYard/PackFlow/NuspecFileGenerator.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/NuspecFileGenerator.cs
@@ -61,6 +61,17 @@ namespace dotnetCampus.SourceYard.PackFlow
         private NuspecPackage GetNuspec(IPackingContext context)
         {
             var buildProps = context.BuildProps;
+
+            Repository repository = null;
+            if (!string.IsNullOrEmpty(buildProps.RepositoryType) && !string.IsNullOrEmpty(buildProps.RepositoryUrl))
+            {
+                repository = new Repository()
+                {
+                    Type = buildProps.RepositoryType,
+                    Url = buildProps.RepositoryUrl
+                };
+            }
+
             return new NuspecPackage()
             {
                 NuspecMetadata = new NuspecMetadata()
@@ -77,7 +88,8 @@ namespace dotnetCampus.SourceYard.PackFlow
                     PackageLicenseUrl = buildProps.PackageLicenseUrl,
                     PackageTags = buildProps.PackageTags,
                     PackageReleaseNotes = buildProps.PackageReleaseNotes,
-                    Dependencies = GetDependencies(context.PackageReferenceVersion)
+                    Dependencies = GetDependencies(context.PackageReferenceVersion),
+                    Repository = repository
                 }
             };
         }

--- a/src/dotnetCampus.SourceYard/PackFlow/nuspec/NuspecMetadata.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/nuspec/NuspecMetadata.cs
@@ -53,6 +53,19 @@ namespace dotnetCampus.SourceYard.PackFlow.Nuspec
         /// </summary>
         [XmlElement("developmentDependency")]
         public string DevelopmentDependency { get; set; } = "true";
+
+        [XmlElement("repository")]
+        public Repository Repository { set; get; }
+    }
+
+    [XmlType(typeName: "repository", Namespace = "")]
+    public class Repository
+    {
+        [XmlAttribute(attributeName: "type")]
+        public string Type { set; get; }
+
+        [XmlAttribute(attributeName: "url")]
+        public string Url { set; get; }
     }
 
     public class NugetTargetFramework

--- a/src/dotnetCampus.SourceYard/Program.cs
+++ b/src/dotnetCampus.SourceYard/Program.cs
@@ -20,7 +20,7 @@ namespace dotnetCampus.SourceYard
         private static void RunOptionsAndReturnExitCode(Options options)
         {
 #if DEBUG
-            // Debugger.Launch();
+            //Debugger.Launch();
             Console.WriteLine(Environment.CommandLine);
 #endif
             var logger = new Logger();
@@ -46,6 +46,8 @@ namespace dotnetCampus.SourceYard
                 var description = ReadFile(options.DescriptionFile);
                 var copyright = ReadFile(options.CopyrightFile);
 
+                
+
                 var buildProps = new BuildProps()
                 {
                     Authors = options.Authors,
@@ -53,15 +55,17 @@ namespace dotnetCampus.SourceYard
                     Owner = options.Owner ?? options.Authors,
                     Copyright = copyright,
                     Description = description,
-                    PackageProjectUrl = options.PackageProjectUrl,
-                    RepositoryType = options.RepositoryType,
-                    RepositoryUrl = options.RepositoryUrl,
+                    //PackageProjectUrl = options.PackageProjectUrl,
+                    //RepositoryType = options.RepositoryType,
+                    //RepositoryUrl = options.RepositoryUrl,
                     Title = options.Title,
                     PackageIconUrl = options.PackageIconUrl,
                     PackageLicenseUrl = options.PackageLicenseUrl,
                     PackageReleaseNotes = options.PackageReleaseNotesFile,
                     PackageTags = options.PackageTags
                 };
+
+                buildProps.SetSourcePackingDirectory(Path.GetFullPath(options.SourcePackingDirectory));
 
                 new Packer(projectFile: projectFile,
                     intermediateDirectory: intermediateDirectory,

--- a/src/dotnetCampus.SourceYard/Utils/BuildProps.cs
+++ b/src/dotnetCampus.SourceYard/Utils/BuildProps.cs
@@ -1,4 +1,9 @@
-﻿namespace dotnetCampus.SourceYard.Utils
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace dotnetCampus.SourceYard.Utils
 {
     public class BuildProps
     {
@@ -39,14 +44,16 @@
         /// <summary>
         ///     仓库地址
         /// </summary>
-        public string RepositoryUrl { get; set; }
+        /// 在 SourceProjectPackageFile.txt 设置
+        public string RepositoryUrl { get; private set; }
 
-        public string RepositoryType { get; set; }
+        public string RepositoryType { get; private set; }
 
         /// <summary>
         ///     项目地址
         /// </summary>
-        public string PackageProjectUrl { get; set; }
+        /// 在 SourceProjectPackageFile.txt 设置
+        public string PackageProjectUrl { get; private set; }
 
         /// <summary>
         ///     版权
@@ -94,10 +101,132 @@
 
         public string PackageTags { get; set; }
 
+        /// <summary>
+        /// 打包用到的文件夹
+        /// </summary>
+        public string SourcePackingDirectory { get; private set; }
+
         private string _authors;
         private string _company;
 
         private string _description;
         private string _owner;
+
+        /// <summary>
+        /// 设置打包用到的文件夹，设置时将会自动读取文件
+        /// </summary>
+        /// <param name="packingDirectory"></param>
+        public void SetSourcePackingDirectory(string packingDirectory)
+        {
+            SourcePackingDirectory = packingDirectory;
+
+            // 更多信息读取
+            var sourceProjectPackageFile = Path.Combine(packingDirectory, "SourceProjectPackageFile.txt");
+
+            // 这个文件里面存放使用 fkv 配置
+            if (File.Exists(sourceProjectPackageFile))
+            {
+                // todo 等待高性能配置发布
+                var configList = DeserializeFile(new FileInfo(sourceProjectPackageFile));
+
+                if (configList.TryGetValue("RepositoryType", out var repositoryType))
+                {
+                    RepositoryType = repositoryType.Trim();
+                }
+
+                if (configList.TryGetValue("PackageProjectUrl", out var packageProjectUrl))
+                {
+                    PackageProjectUrl = packageProjectUrl.Trim();
+                }
+
+                if (configList.TryGetValue("RepositoryUrl", out var repositoryUrl))
+                {
+                    RepositoryUrl = repositoryUrl.Trim();
+                }
+            }
+        }
+
+        // 这里代码从Configurations复制
+        private Dictionary<string, string> DeserializeFile(FileInfo file)
+        {
+            // 一次性读取完的性能最好
+            var str = File.ReadAllText(file.FullName);
+            str = str.Replace("\r\n", "\n");
+            return Deserialize(str);
+        }
+        private static string _splitString = ">";
+
+        private static string _escapeString = "?";
+
+        /// <summary>
+        /// 反序列化的核心实现，反序列化字符串
+        /// </summary>
+        /// <param name="str"></param>
+        private Dictionary<string, string> Deserialize(string str)
+        {
+            var keyValuePairList = str.Split('\n');
+            var keyValue = new Dictionary<string, string>(StringComparer.Ordinal);
+            string? key = null;
+            var splitString = _splitString;
+
+            foreach (var temp in keyValuePairList.Select(temp => temp.Trim()))
+            {
+                if (temp.StartsWith(splitString, StringComparison.Ordinal))
+                {
+                    // 分割，可以作为注释，这一行忽略
+                    // 下一行必须是key
+                    key = null;
+                    continue;
+                }
+
+                var unescapedString = UnescapeString(temp);
+
+                if (key == null)
+                {
+                    key = unescapedString;
+
+                    // 文件存在多个地方都记录相同的值
+                    // 如果有多个地方记录相同的值，使用最后的值替换前面文件
+                    if (keyValue.ContainsKey(key))
+                    {
+                        keyValue.Remove(key);
+                    }
+                }
+                else
+                {
+                    if (keyValue.ContainsKey(key))
+                    {
+                        // key
+                        // v1
+                        // v2
+                        // 返回 {"key","v1\nv2"}
+                        keyValue[key] = keyValue[key] + "\n" + unescapedString;
+                    }
+                    else
+                    {
+                        keyValue.Add(key, unescapedString);
+                    }
+                }
+            }
+
+            return keyValue;
+        }
+
+        /// <summary>
+        /// 存储的反转义
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        private static string UnescapeString(string str)
+        {
+            var escapeString = _escapeString;
+
+            if (str.StartsWith(escapeString, StringComparison.Ordinal))
+            {
+                return str.Substring(1);
+            }
+
+            return str;
+        }
     }
 }

--- a/src/dotnetCampus.SourceYard/dotnetCampus.SourceYard.csproj
+++ b/src/dotnetCampus.SourceYard/dotnetCampus.SourceYard.csproj
@@ -10,6 +10,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DevelopmentDependency>true</DevelopmentDependency>
+    <PackageProjectUrl>https://github.com/dotnet-campus/SourceYard</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/dotnet-campus/SourceYard</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <!-- 因为只把主软件复制过去，依赖的库没有复制，所以不使用这个方法 -->
     <!-- 在下面可以看到使用的是复制整个文件夹 -->
     <!--<BuildOutputTargetFolder>tools</BuildOutputTargetFolder>-->
@@ -51,7 +54,7 @@
     <!--指定自己的在安装 nuget 时修改编译-->
     <None Include="Assets\Current\**" Pack="True" PackagePath="build\" />
     <None Include="Assets\README.md" Pack="True" PackagePath="" />
-    <None Include="$(OutputPath)**\**" Pack="True" PackagePath="tools\" Visible="false"/>
+    <None Include="$(OutputPath)**\**" Pack="True" PackagePath="tools\" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
修复 https://github.com/dotnet-campus/SourceYard/issues/44

[Roslyn 在多开发框架让 msbuild 的 Target 仅运行一次](https://blog.lindexi.com/post/Roslyn-%E5%9C%A8%E5%A4%9A%E5%BC%80%E5%8F%91%E6%A1%86%E6%9E%B6%E8%AE%A9-msbuild-%E7%9A%84-Target-%E4%BB%85%E8%BF%90%E8%A1%8C%E4%B8%80%E6%AC%A1.html)

现在 github 可以上传 nuget 文件，在打包可以给项目仓库的链接这样打出来的文件将会添加代码

    <repository type="git" url="https://github.com/dotnet-campus/Configurations" />
