### PR TITLE
修复逗比问题

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.19027-alpha</Version>
+    <Version>0.1.19029-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/dotnetCampus.SourceYard.targets
@@ -4,7 +4,7 @@
 
     <Target Name="BuildSourceNuGet" AfterTargets="Build"
             DependsOnTargets="SourceYard"
-            Condition="$(PackSource) != 'False' And '$(TargetFrameworks)' == ''">
+            Condition="$(PackSource) != 'False'">
 
     </Target>
 


### PR DESCRIPTION
删除多框架打包的时候判断多框架是空才执行，但是此时是多框架调用也就是多框架一定不是空字符串