### PR TITLE
开发者设置文件放在NuGet包的路径

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.19309-alpha</Version>
+    <Version>0.1.19317-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.19262-alpha</Version>
+    <Version>0.1.19309-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -16,6 +16,7 @@
     </ItemGroup>
   </Target>
 
+  <!--打包第一步，将会多个框架分别执行-->
   <Target Name="SourceYardStep1">
     <PropertyGroup>
       <SourcePackingDirectory>$(IntermediateOutputPath)SourcePacking\</SourcePackingDirectory>
@@ -74,6 +75,7 @@
 
   </Target>
   
+  <!--打包第二步，将会多个框架分别执行-->
   <Target Name="SourceYardStep2">
     
     <MakeDir Condition="!Exists($(SourcePackingDirectory))" Directories="$(SourcePackingDirectory)"></MakeDir>
@@ -104,6 +106,7 @@
     <WriteLinesToFile File="$(SourceYardCompilePackageFile)" Lines="@(_SourceYardCompilePackage)" Overwrite="true"></WriteLinesToFile>
   </Target>
   
+  <!--打包第三步，无论多框架还是单框架只执行一次-->
   <Target Name="SourceYardStep3">
     <Exec
         Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) --SourcePackingDirectory $(SourcePackingDirectory) --TargetFrameworks &quot;$(TargetFrameworks) &quot; --TargetFramework &quot;$(TargetFramework) &quot;">

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -36,11 +36,20 @@
       <PackageReferenceVersionFile>$(SourcePackingDirectory)PackageReferenceVersionFile.txt</PackageReferenceVersionFile>
       <SourceProjectPackageFile>$(SourcePackingDirectory)SourceProjectPackageFile.txt</SourceProjectPackageFile>
       <SourceYardPackageReferenceFile>$(SourcePackingDirectory)SourceYardPackageReferenceFile.txt</SourceYardPackageReferenceFile>
+
       <SourceYardCompilePackageFile>$(SourcePackingDirectory)SourceYardCompilePackageFile.txt</SourceYardCompilePackageFile>
+      <SourceYardResourcePackageFile>$(SourcePackingDirectory)SourceYardResourcePackageFile.txt</SourceYardResourcePackageFile>
+      <SourceYardContentPackageFile>$(SourcePackingDirectory)SourceYardContentPackageFile.txt</SourceYardContentPackageFile>
+      <SourceYardNonePackageFile>$(SourcePackingDirectory)SourceYardNonePackageFile.txt</SourceYardNonePackageFile>
+      <SourceYardEmbeddedResourcePackageFile>$(SourcePackingDirectory)SourceYardEmbeddedResourcePackageFile.txt</SourceYardEmbeddedResourcePackageFile>
     </PropertyGroup>
 
     <ItemGroup>
       <_SourceYardCompilePackage Include="%(SourceYardCompile.Identity)|%(SourceYardCompile.SourcePackagePath)"/>
+      <_SourceYardResourcePackage Include="%(SourceYardResource.Identity)|%(SourceYardResource.SourcePackagePath)"/>
+      <_SourceYardContentPackage Include="%(SourceYardContent.Identity)|%(SourceYardContent.SourcePackagePath)"/>
+      <_SourceYardNonePackage Include="%(SourceYardNone.Identity)|%(SourceYardNone.SourcePackagePath)"/>
+      <_SourceYardEmbeddedResourcePackage Include="%(SourceYardEmbeddedResource.Identity)|%(SourceYardEmbeddedResource.SourcePackagePath)"/>
     </ItemGroup>
 
     <PropertyGroup>
@@ -104,6 +113,10 @@
     <WriteLinesToFile File="$(SourceYardPackageReferenceFile)" Lines="$(SourceYardPackageReference)" Overwrite="true"></WriteLinesToFile>
 
     <WriteLinesToFile File="$(SourceYardCompilePackageFile)" Lines="@(_SourceYardCompilePackage)" Overwrite="true"></WriteLinesToFile>
+    <WriteLinesToFile File="$(SourceYardResourcePackageFile)" Lines="@(_SourceYardResourcePackage)" Overwrite="true"></WriteLinesToFile>
+    <WriteLinesToFile File="$(SourceYardContentPackageFile)" Lines="@(_SourceYardContentPackage)" Overwrite="true"></WriteLinesToFile>
+    <WriteLinesToFile File="$(SourceYardNonePackageFile)" Lines="@(_SourceYardNonePackage)" Overwrite="true"></WriteLinesToFile>
+    <WriteLinesToFile File="$(SourceYardEmbeddedResourcePackageFile)" Lines="@(_SourceYardEmbeddedResourcePackage)" Overwrite="true"></WriteLinesToFile>
   </Target>
   
   <!--打包第三步，无论多框架还是单框架只执行一次-->

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -1,122 +1,125 @@
 ﻿<Project>
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
-  
-  <!-- 打包核心 -->
-
-  <Target Name="_SourceYardPrivateAssets"
-          BeforeTargets="CollectPackageReferences">
-    <!-- 读取信息，解决 https://github.com/dotnet/sdk/issues/12777 -->
-    <ItemGroup>
-      <_PackageReferenceVersion
-          Include="Name='%(PackageReference.Identity)' Version='%(PackageReference.Version)' PrivateAssets='%(PackageReference.PrivateAssets)'">
-      </_PackageReferenceVersion>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="SourceYardStep1">
     <PropertyGroup>
-      <SourcePackingDirectory>$(IntermediateOutputPath)SourcePacking\</SourcePackingDirectory>
-
-      <CompileTextFile>$(SourcePackingDirectory)CompileFile.txt</CompileTextFile>
-      <ResourceTextFile>$(SourcePackingDirectory)ResourceFile.txt</ResourceTextFile>
-      <ContentTextFile>$(SourcePackingDirectory)ContentFile.txt</ContentTextFile>
-      <NoneTextFile>$(SourcePackingDirectory)NoneFile.txt</NoneTextFile>
-      <EmbeddedResourceTextFile>$(SourcePackingDirectory)EmbeddedResourceFile.txt</EmbeddedResourceTextFile>
-      <PageTextFile>$(SourcePackingDirectory)PageFile.txt</PageTextFile>
-      <ApplicationDefinitionTextFile>$(SourcePackingDirectory)ApplicationDefinitionFile.txt</ApplicationDefinitionTextFile>
-
-      <DescriptionFile>$(SourcePackingDirectory)DescriptionFile.txt</DescriptionFile>
-      <CopyrightFile>$(SourcePackingDirectory)CopyrightFile.txt</CopyrightFile>
-      <PackageReleaseNotesFile>$(SourcePackingDirectory)PackageReleaseNotesFile.txt</PackageReleaseNotesFile>
-
-      <PackageReferenceVersionFile>$(SourcePackingDirectory)PackageReferenceVersionFile.txt</PackageReferenceVersionFile>
-      <SourceProjectPackageFile>$(SourcePackingDirectory)SourceProjectPackageFile.txt</SourceProjectPackageFile>
-      <SourceYardPackageReferenceFile>$(SourcePackingDirectory)SourceYardPackageReferenceFile.txt</SourceYardPackageReferenceFile>
+        <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     </PropertyGroup>
 
-    <PropertyGroup>
+    <!-- 打包核心 -->
 
-      <SourceYardAuthors Condition="$(Authors) != ''">--Authors "$(Authors)"</SourceYardAuthors>
+    <Target Name="_SourceYardPrivateAssets"
+            BeforeTargets="CollectPackageReferences">
+        <!-- 读取信息，解决 https://github.com/dotnet/sdk/issues/12777 -->
+        <ItemGroup>
+            <_PackageReferenceVersion
+                Include="Name='%(PackageReference.Identity)' Version='%(PackageReference.Version)' PrivateAssets='%(PackageReference.PrivateAssets)'">
+            </_PackageReferenceVersion>
+        </ItemGroup>
+    </Target>
 
-      <!-- 这部分长度太长会让命令行无法输入
+    <!--打包第一步，将会多个框架分别执行-->
+    <Target Name="SourceYardStep1">
+        <PropertyGroup>
+            <SourcePackingDirectory>$(IntermediateOutputPath)SourcePacking\</SourcePackingDirectory>
+
+            <CompileTextFile>$(SourcePackingDirectory)CompileFile.txt</CompileTextFile>
+            <ResourceTextFile>$(SourcePackingDirectory)ResourceFile.txt</ResourceTextFile>
+            <ContentTextFile>$(SourcePackingDirectory)ContentFile.txt</ContentTextFile>
+            <NoneTextFile>$(SourcePackingDirectory)NoneFile.txt</NoneTextFile>
+            <EmbeddedResourceTextFile>$(SourcePackingDirectory)EmbeddedResourceFile.txt</EmbeddedResourceTextFile>
+            <PageTextFile>$(SourcePackingDirectory)PageFile.txt</PageTextFile>
+            <ApplicationDefinitionTextFile>$(SourcePackingDirectory)ApplicationDefinitionFile.txt</ApplicationDefinitionTextFile>
+
+            <DescriptionFile>$(SourcePackingDirectory)DescriptionFile.txt</DescriptionFile>
+            <CopyrightFile>$(SourcePackingDirectory)CopyrightFile.txt</CopyrightFile>
+            <PackageReleaseNotesFile>$(SourcePackingDirectory)PackageReleaseNotesFile.txt</PackageReleaseNotesFile>
+
+            <PackageReferenceVersionFile>$(SourcePackingDirectory)PackageReferenceVersionFile.txt</PackageReferenceVersionFile>
+            <SourceProjectPackageFile>$(SourcePackingDirectory)SourceProjectPackageFile.txt</SourceProjectPackageFile>
+            <SourceYardPackageReferenceFile>$(SourcePackingDirectory)SourceYardPackageReferenceFile.txt</SourceYardPackageReferenceFile>
+        </PropertyGroup>
+
+        <PropertyGroup>
+
+            <SourceYardAuthors Condition="$(Authors) != ''">--Authors "$(Authors)"</SourceYardAuthors>
+
+            <!-- 这部分长度太长会让命令行无法输入
 			<SourceYardRepositoryUrl Condition="$(RepositoryUrl) != ''">RepositoryUrl "$(RepositoryUrl)"</SourceYardRepositoryUrl>
             <SourceYardRepositoryType Condition="$(RepositoryType) != ''">RepositoryType "$(RepositoryType)"</SourceYardRepositoryType>
             <SourceYardPackageProjectUrl Condition="$(PackageProjectUrl) != ''">PackageProjectUrl "$(PackageProjectUrl)"</SourceYardPackageProjectUrl>-->
-      <SourceYardPackageLicenseUrl Condition="$(PackageLicenseUrl) != ''">--PackageLicenseUrl "$(PackageLicenseUrl) "</SourceYardPackageLicenseUrl>
+            <SourceYardPackageLicenseUrl Condition="$(PackageLicenseUrl) != ''">--PackageLicenseUrl "$(PackageLicenseUrl) "</SourceYardPackageLicenseUrl>
 
-      <SourceYardCopyright Condition="$(Copyright) != ''">--CopyrightFile "$(CopyrightFile)"</SourceYardCopyright>
+            <SourceYardCopyright Condition="$(Copyright) != ''">--CopyrightFile "$(CopyrightFile)"</SourceYardCopyright>
 
-      <SourceYardPackageVersion Condition="$(PackageVersion) != ''">-v $(PackageVersion)</SourceYardPackageVersion>
+            <SourceYardPackageVersion Condition="$(PackageVersion) != ''">-v $(PackageVersion)</SourceYardPackageVersion>
 
-      <SourceYardDescription Condition="$(Description) != ''">--DescriptionFile "$(DescriptionFile) "</SourceYardDescription>
+            <SourceYardDescription Condition="$(Description) != ''">--DescriptionFile "$(DescriptionFile) "</SourceYardDescription>
 
-      <SourceYardTitle Condition="$(Title) != ''">--Title "$(Title)"</SourceYardTitle>
-      <SourceYardOwner Condition="$(Owner) != ''">--Owner "$(Owner)"</SourceYardOwner>
-      <SourceYardPackageTags Condition="$(PackageTags) != ''">--PackageTags "$(PackageTags) "</SourceYardPackageTags>
-      <SourceYardPackageReleaseNotes Condition="$(PackageReleaseNotes) != ''"> --PackageReleaseNotesFile $(PackageReleaseNotesFile)</SourceYardPackageReleaseNotes>
-      <SourceYardPackageId Condition="'$(PackageId)' != ''">--PackageId "$(PackageId) "</SourceYardPackageId>
+            <SourceYardTitle Condition="$(Title) != ''">--Title "$(Title)"</SourceYardTitle>
+            <SourceYardOwner Condition="$(Owner) != ''">--Owner "$(Owner)"</SourceYardOwner>
+            <SourceYardPackageTags Condition="$(PackageTags) != ''">--PackageTags "$(PackageTags) "</SourceYardPackageTags>
+            <SourceYardPackageReleaseNotes Condition="$(PackageReleaseNotes) != ''"> --PackageReleaseNotesFile $(PackageReleaseNotesFile)</SourceYardPackageReleaseNotes>
+            <SourceYardPackageId Condition="'$(PackageId)' != ''">--PackageId "$(PackageId) "</SourceYardPackageId>
 
-      <SourceMSBuildProjectFullPath>-p "$(MSBuildProjectFullPath) "</SourceMSBuildProjectFullPath>
-      <SourceIntermediateDirectory>-i "$(SourcePackingDirectory)Package "</SourceIntermediateDirectory>
-      <SourcePackageOutputPath Condition="'$(PackageOutputPath)' != ''">-n "$(PackageOutputPath) "</SourcePackageOutputPath>
-      <SourcePackageOutputPath Condition="'$(PackageOutputPath)' == '' and $(OutputPath) != ''">-n "$(OutputPath) "</SourcePackageOutputPath>
-      <SourcePackageReferenceVersion>--PackageReferenceVersion "$(PackageReferenceVersionFile)"</SourcePackageReferenceVersion>
+            <SourceMSBuildProjectFullPath>-p "$(MSBuildProjectFullPath) "</SourceMSBuildProjectFullPath>
+            <SourceIntermediateDirectory>-i "$(SourcePackingDirectory)Package "</SourceIntermediateDirectory>
+            <SourcePackageOutputPath Condition="'$(PackageOutputPath)' != ''">-n "$(PackageOutputPath) "</SourcePackageOutputPath>
+            <SourcePackageOutputPath Condition="'$(PackageOutputPath)' == '' and $(OutputPath) != ''">-n "$(OutputPath) "</SourcePackageOutputPath>
+            <SourcePackageReferenceVersion>--PackageReferenceVersion "$(PackageReferenceVersionFile)"</SourcePackageReferenceVersion>
 
-    </PropertyGroup>
+        </PropertyGroup>
 
-  </Target>
-  
-  <Target Name="SourceYardStep2">
-    
-    <MakeDir Condition="!Exists($(SourcePackingDirectory))" Directories="$(SourcePackingDirectory)"></MakeDir>
+    </Target>
 
-    <WriteLinesToFile File="$(CompileTextFile)" Lines="@(Compile)" Overwrite="true" />
-    <WriteLinesToFile File="$(ResourceTextFile)" Lines="@(Resource)" Overwrite="true" />
-    <WriteLinesToFile File="$(ContentTextFile)" Lines="@(Content)" Overwrite="true" />
-    <WriteLinesToFile File="$(NoneTextFile)" Lines="@(None)" Overwrite="true" />
-    <WriteLinesToFile File="$(EmbeddedResourceTextFile)" Lines="@(EmbeddedResource)" Overwrite="true" />
-    <WriteLinesToFile File="$(PageTextFile)" Lines="@(Page)" Overwrite="true" />
-    <WriteLinesToFile File="$(ApplicationDefinitionTextFile)" Lines="@(ApplicationDefinition)" Overwrite="true" />
+    <!--打包第二步，将会多个框架分别执行-->
+    <Target Name="SourceYardStep2">
 
-    <WriteLinesToFile File="$(DescriptionFile)" Lines="$(Description)" Overwrite="true"></WriteLinesToFile>
-    <WriteLinesToFile File="$(CopyrightFile)" Lines="$(Copyright)" Overwrite="true"></WriteLinesToFile>
-    <WriteLinesToFile File="$(PackageReleaseNotesFile)" Lines="$(PackageReleaseNotes)" Overwrite="true"></WriteLinesToFile>
+        <MakeDir Condition="!Exists($(SourcePackingDirectory))" Directories="$(SourcePackingDirectory)"></MakeDir>
 
-    <!-- 写入通用的信息 -->
-    <!-- 多段写入之前需要先删除文件 -->
-    <Delete Files="$(SourceProjectPackageFile)" Condition="Exists($(SourceProjectPackageFile))"></Delete>
-    <!-- 先写入RepositoryType的值，解析时将会根据此值顺序解析 -->
-    <WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;RepositoryType;$(RepositoryType);"></WriteLinesToFile>
-    <WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;PackageProjectUrl;$(PackageProjectUrl);"></WriteLinesToFile>
-    <WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;RepositoryUrl;$(RepositoryUrl);"></WriteLinesToFile>
+        <WriteLinesToFile File="$(CompileTextFile)" Lines="@(Compile)" Overwrite="true" />
+        <WriteLinesToFile File="$(ResourceTextFile)" Lines="@(Resource)" Overwrite="true" />
+        <WriteLinesToFile File="$(ContentTextFile)" Lines="@(Content)" Overwrite="true" />
+        <WriteLinesToFile File="$(NoneTextFile)" Lines="@(None)" Overwrite="true" />
+        <WriteLinesToFile File="$(EmbeddedResourceTextFile)" Lines="@(EmbeddedResource)" Overwrite="true" />
+        <WriteLinesToFile File="$(PageTextFile)" Lines="@(Page)" Overwrite="true" />
+        <WriteLinesToFile File="$(ApplicationDefinitionTextFile)" Lines="@(ApplicationDefinition)" Overwrite="true" />
 
-    <WriteLinesToFile File="$(PackageReferenceVersionFile)" Lines="@(_PackageReferenceVersion)" Overwrite="true" />
-    <WriteLinesToFile File="$(SourceYardPackageReferenceFile)" Lines="$(SourceYardPackageReference)" Overwrite="true"></WriteLinesToFile>
-  </Target>
-  
-  <Target Name="SourceYardStep3">
-    <Exec
-        Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) --SourcePackingDirectory $(SourcePackingDirectory) --TargetFrameworks &quot;$(TargetFrameworks) &quot; --TargetFramework &quot;$(TargetFramework) &quot;">
-    </Exec>
-  </Target>
+        <WriteLinesToFile File="$(DescriptionFile)" Lines="$(Description)" Overwrite="true"></WriteLinesToFile>
+        <WriteLinesToFile File="$(CopyrightFile)" Lines="$(Copyright)" Overwrite="true"></WriteLinesToFile>
+        <WriteLinesToFile File="$(PackageReleaseNotesFile)" Lines="$(PackageReleaseNotes)" Overwrite="true"></WriteLinesToFile>
 
-  <PropertyGroup>
-    <CleanDependsOn>$(CleanDependsOn);_SourceYardClean</CleanDependsOn>
-  </PropertyGroup>
+        <!-- 写入通用的信息 -->
+        <!-- 多段写入之前需要先删除文件 -->
+        <Delete Files="$(SourceProjectPackageFile)" Condition="Exists($(SourceProjectPackageFile))"></Delete>
+        <!-- 先写入RepositoryType的值，解析时将会根据此值顺序解析 -->
+        <WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;RepositoryType;$(RepositoryType);"></WriteLinesToFile>
+        <WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;PackageProjectUrl;$(PackageProjectUrl);"></WriteLinesToFile>
+        <WriteLinesToFile File="$(SourceProjectPackageFile)" Lines=">;RepositoryUrl;$(RepositoryUrl);"></WriteLinesToFile>
 
-  <Target Name="_SourceYardClean">
+        <WriteLinesToFile File="$(PackageReferenceVersionFile)" Lines="@(_PackageReferenceVersion)" Overwrite="true" />
+        <WriteLinesToFile File="$(SourceYardPackageReferenceFile)" Lines="$(SourceYardPackageReference)" Overwrite="true"></WriteLinesToFile>
+    </Target>
+
+    <!--打包第三步，无论多框架还是单框架只执行一次-->
+    <Target Name="SourceYardStep3">
+        <Exec
+            Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) --SourcePackingDirectory $(SourcePackingDirectory) --TargetFrameworks &quot;$(TargetFrameworks) &quot; --TargetFramework &quot;$(TargetFramework) &quot;">
+        </Exec>
+    </Target>
+
     <PropertyGroup>
-      <_SourcePackingDirectory>$(IntermediateOutputPath)SourcePacking\</_SourcePackingDirectory>
+        <CleanDependsOn>$(CleanDependsOn);_SourceYardClean</CleanDependsOn>
     </PropertyGroup>
-    <RemoveDir Directories="$(_SourcePackingDirectory)" />
-  </Target>
 
-  <Target Name="SourceYardFalsePackSource" AfterTargets="Build"
-          Condition="$(PackSource) == 'False'">
-    <Message Text="因为用户设置 PackSource 为 false 所以没有打包源代码"></Message>
-  </Target>
+    <Target Name="_SourceYardClean">
+        <PropertyGroup>
+            <_SourcePackingDirectory>$(IntermediateOutputPath)SourcePacking\</_SourcePackingDirectory>
+        </PropertyGroup>
+        <RemoveDir Directories="$(_SourcePackingDirectory)" />
+    </Target>
+
+    <Target Name="SourceYardFalsePackSource" AfterTargets="Build"
+            Condition="$(PackSource) == 'False'">
+        <Message Text="因为用户设置 PackSource 为 false 所以没有打包源代码"></Message>
+    </Target>
 
 </Project>

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -42,6 +42,9 @@
       <SourceYardContentPackageFile>$(SourcePackingDirectory)SourceYardContentPackageFile.txt</SourceYardContentPackageFile>
       <SourceYardNonePackageFile>$(SourcePackingDirectory)SourceYardNonePackageFile.txt</SourceYardNonePackageFile>
       <SourceYardEmbeddedResourcePackageFile>$(SourcePackingDirectory)SourceYardEmbeddedResourcePackageFile.txt</SourceYardEmbeddedResourcePackageFile>
+
+      <!-- 这是给 SourceFusion 预编译生成的文件加入打包 -->
+      <SourceYardForSourceFusionCompilePackageFile>$(SourcePackingDirectory)SourceYardForSourceFusionCompilePackageFile.txt</SourceYardForSourceFusionCompilePackageFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -50,6 +53,7 @@
       <_SourceYardContentPackage Include="%(SourceYardContent.Identity)|%(SourceYardContent.SourcePackagePath)"/>
       <_SourceYardNonePackage Include="%(SourceYardNone.Identity)|%(SourceYardNone.SourcePackagePath)"/>
       <_SourceYardEmbeddedResourcePackage Include="%(SourceYardEmbeddedResource.Identity)|%(SourceYardEmbeddedResource.SourcePackagePath)"/>
+      <_SourceYardForSourceFusionCompilePackage Include="%(_SourceFusionIncludedCompileFile.Identity)|SourceFusionGeneratedCode\%(_SourceFusionIncludedCompileFile.Identity)"/>
     </ItemGroup>
 
     <PropertyGroup>
@@ -117,6 +121,7 @@
     <WriteLinesToFile File="$(SourceYardContentPackageFile)" Lines="@(_SourceYardContentPackage)" Overwrite="true"></WriteLinesToFile>
     <WriteLinesToFile File="$(SourceYardNonePackageFile)" Lines="@(_SourceYardNonePackage)" Overwrite="true"></WriteLinesToFile>
     <WriteLinesToFile File="$(SourceYardEmbeddedResourcePackageFile)" Lines="@(_SourceYardEmbeddedResourcePackage)" Overwrite="true"></WriteLinesToFile>
+    <WriteLinesToFile File="$(SourceYardForSourceFusionCompilePackageFile)" Lines="@(_SourceYardForSourceFusionCompilePackage)" Overwrite="true"></WriteLinesToFile>
   </Target>
   
   <!--打包第三步，无论多框架还是单框架只执行一次-->

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -42,9 +42,6 @@
       <SourceYardContentPackageFile>$(SourcePackingDirectory)SourceYardContentPackageFile.txt</SourceYardContentPackageFile>
       <SourceYardNonePackageFile>$(SourcePackingDirectory)SourceYardNonePackageFile.txt</SourceYardNonePackageFile>
       <SourceYardEmbeddedResourcePackageFile>$(SourcePackingDirectory)SourceYardEmbeddedResourcePackageFile.txt</SourceYardEmbeddedResourcePackageFile>
-
-      <!-- 这是给 SourceFusion 预编译生成的文件加入打包 -->
-      <SourceYardForSourceFusionCompilePackageFile>$(SourcePackingDirectory)SourceYardForSourceFusionCompilePackageFile.txt</SourceYardForSourceFusionCompilePackageFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -53,6 +50,8 @@
       <_SourceYardContentPackage Include="%(SourceYardContent.Identity)|%(SourceYardContent.SourcePackagePath)"/>
       <_SourceYardNonePackage Include="%(SourceYardNone.Identity)|%(SourceYardNone.SourcePackagePath)"/>
       <_SourceYardEmbeddedResourcePackage Include="%(SourceYardEmbeddedResource.Identity)|%(SourceYardEmbeddedResource.SourcePackagePath)"/>
+
+      <!-- 这是给 SourceFusion 预编译生成的文件加入打包 -->
       <_SourceYardForSourceFusionCompilePackage Include="%(_SourceFusionIncludedCompileFile.Identity)|SourceFusionGeneratedCode\%(_SourceFusionIncludedCompileFile.Identity)"/>
     </ItemGroup>
 
@@ -117,11 +116,14 @@
     <WriteLinesToFile File="$(SourceYardPackageReferenceFile)" Lines="$(SourceYardPackageReference)" Overwrite="true"></WriteLinesToFile>
 
     <WriteLinesToFile File="$(SourceYardCompilePackageFile)" Lines="@(_SourceYardCompilePackage)" Overwrite="true"></WriteLinesToFile>
+    <!-- 这是给 SourceFusion 预编译生成的文件加入打包，写入在 SourceYardCompilePackageFile 文件 -->
+    <WriteLinesToFile File="$(SourceYardCompilePackageFile)" Lines="@(_SourceYardForSourceFusionCompilePackage)"></WriteLinesToFile>
+
     <WriteLinesToFile File="$(SourceYardResourcePackageFile)" Lines="@(_SourceYardResourcePackage)" Overwrite="true"></WriteLinesToFile>
     <WriteLinesToFile File="$(SourceYardContentPackageFile)" Lines="@(_SourceYardContentPackage)" Overwrite="true"></WriteLinesToFile>
     <WriteLinesToFile File="$(SourceYardNonePackageFile)" Lines="@(_SourceYardNonePackage)" Overwrite="true"></WriteLinesToFile>
     <WriteLinesToFile File="$(SourceYardEmbeddedResourcePackageFile)" Lines="@(_SourceYardEmbeddedResourcePackage)" Overwrite="true"></WriteLinesToFile>
-    <WriteLinesToFile File="$(SourceYardForSourceFusionCompilePackageFile)" Lines="@(_SourceYardForSourceFusionCompilePackage)" Overwrite="true"></WriteLinesToFile>
+
   </Target>
   
   <!--打包第三步，无论多框架还是单框架只执行一次-->

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -52,7 +52,7 @@
       <_SourceYardEmbeddedResourcePackage Include="%(SourceYardEmbeddedResource.Identity)|%(SourceYardEmbeddedResource.SourcePackagePath)"/>
 
       <!-- 这是给 SourceFusion 预编译生成的文件加入打包 -->
-      <_SourceYardForSourceFusionCompilePackage Include="%(_SourceFusionIncludedCompileFile.Identity)|SourceFusionGeneratedCode\%(_SourceFusionIncludedCompileFile.Identity)"/>
+      <_SourceYardForSourceFusionCompilePackage Include="%(_SourceFusionIncludedCompileFile.Identity)|%(_SourceFusionIncludedCompileFile.Identity)"/>
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/dotnetCampus.SourceYard/Context/PackagedProjectFile.cs
+++ b/src/dotnetCampus.SourceYard/Context/PackagedProjectFile.cs
@@ -21,6 +21,11 @@ namespace dotnetCampus.SourceYard.Context
             ApplicationDefinition = applicationDefinition;
 
             CompileFileList = GetSourceYardPackageFileList(compileFile, SourceYardCompilePackageFile);
+
+            // 加上对 SourceFusion 的支持
+            CompileFileList = CombineSourceYardPackageFileList(CompileFileList,
+                ParseSourceYardPackageFile(SourceYardForSourceFusionCompilePackageFile));
+
             ResourceFileList = GetSourceYardPackageFileList(resourceFile, SourceYardResourcePackageFile);
             ContentFileList = GetSourceYardPackageFileList(contentFile, SourceYardContentPackageFile);
             PageList = GetFileList(page);
@@ -33,7 +38,8 @@ namespace dotnetCampus.SourceYard.Context
             SourceYardResourcePackageFile = "SourceYardResourcePackageFile.txt",
             SourceYardContentPackageFile = "SourceYardContentPackageFile.txt",
             SourceYardNonePackageFile = "SourceYardNonePackageFile.txt",
-            SourceYardEmbeddedResourcePackageFile = "SourceYardEmbeddedResourcePackageFile.txt";
+            SourceYardEmbeddedResourcePackageFile = "SourceYardEmbeddedResourcePackageFile.txt",
+            SourceYardForSourceFusionCompilePackageFile = "SourceYardForSourceFusionCompilePackageFile.txt";
 
         /// <summary>
         /// 需要做源码包的项目的编译的文件
@@ -81,7 +87,14 @@ namespace dotnetCampus.SourceYard.Context
             var sourceYardPackageFileList = ParseSourceYardPackageFile(sourceYardPackageFile);
 
             var fileList = GetFileList(file);
-            return new CombineReadonlyList<SourceYardPackageFile>(sourceYardPackageFileList, fileList).Distinct(new SourceYardPackageFileEqualityComparer()).ToList();
+            
+            return CombineSourceYardPackageFileList(sourceYardPackageFileList, fileList);
+        }
+
+        private List<SourceYardPackageFile> CombineSourceYardPackageFileList(
+            params IReadOnlyList<SourceYardPackageFile>[] sourceYardPackageFile)
+        {
+            return new CombineReadonlyList<SourceYardPackageFile>(sourceYardPackageFile).Distinct(new SourceYardPackageFileEqualityComparer()).ToList();
         }
 
         private List<SourceYardPackageFile> ParseSourceYardPackageFile(string sourceYardPackageFile)

--- a/src/dotnetCampus.SourceYard/Context/PackagedProjectFile.cs
+++ b/src/dotnetCampus.SourceYard/Context/PackagedProjectFile.cs
@@ -21,11 +21,6 @@ namespace dotnetCampus.SourceYard.Context
             ApplicationDefinition = applicationDefinition;
 
             CompileFileList = GetSourceYardPackageFileList(compileFile, SourceYardCompilePackageFile);
-
-            // 加上对 SourceFusion 的支持
-            CompileFileList = CombineSourceYardPackageFileList(CompileFileList,
-                ParseSourceYardPackageFile(SourceYardForSourceFusionCompilePackageFile));
-
             ResourceFileList = GetSourceYardPackageFileList(resourceFile, SourceYardResourcePackageFile);
             ContentFileList = GetSourceYardPackageFileList(contentFile, SourceYardContentPackageFile);
             PageList = GetFileList(page);
@@ -38,8 +33,7 @@ namespace dotnetCampus.SourceYard.Context
             SourceYardResourcePackageFile = "SourceYardResourcePackageFile.txt",
             SourceYardContentPackageFile = "SourceYardContentPackageFile.txt",
             SourceYardNonePackageFile = "SourceYardNonePackageFile.txt",
-            SourceYardEmbeddedResourcePackageFile = "SourceYardEmbeddedResourcePackageFile.txt",
-            SourceYardForSourceFusionCompilePackageFile = "SourceYardForSourceFusionCompilePackageFile.txt";
+            SourceYardEmbeddedResourcePackageFile = "SourceYardEmbeddedResourcePackageFile.txt";
 
         /// <summary>
         /// 需要做源码包的项目的编译的文件
@@ -87,14 +81,7 @@ namespace dotnetCampus.SourceYard.Context
             var sourceYardPackageFileList = ParseSourceYardPackageFile(sourceYardPackageFile);
 
             var fileList = GetFileList(file);
-            
-            return CombineSourceYardPackageFileList(sourceYardPackageFileList, fileList);
-        }
-
-        private List<SourceYardPackageFile> CombineSourceYardPackageFileList(
-            params IReadOnlyList<SourceYardPackageFile>[] sourceYardPackageFile)
-        {
-            return new CombineReadonlyList<SourceYardPackageFile>(sourceYardPackageFile).Distinct(new SourceYardPackageFileEqualityComparer()).ToList();
+            return new CombineReadonlyList<SourceYardPackageFile>(sourceYardPackageFileList, fileList).Distinct(new SourceYardPackageFileEqualityComparer()).ToList();
         }
 
         private List<SourceYardPackageFile> ParseSourceYardPackageFile(string sourceYardPackageFile)

--- a/src/dotnetCampus.SourceYard/Context/SourceYardPackageFile.cs
+++ b/src/dotnetCampus.SourceYard/Context/SourceYardPackageFile.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+
+namespace dotnetCampus.SourceYard.Context
+{
+    /// <summary>
+    /// 放在源代码包的文件
+    /// </summary>
+    public class SourceYardPackageFile
+    {
+        public SourceYardPackageFile(FileInfo sourceFile, string sourcePackagePath)
+        {
+            SourceFile = sourceFile;
+            SourcePackagePath = sourcePackagePath;
+        }
+
+        /// <summary>
+        /// 源代码的文件
+        /// </summary>
+        public FileInfo SourceFile { get; }
+
+        /// <summary>
+        /// 打包的路径
+        /// </summary>
+        public string SourcePackagePath { get; }
+    }
+}

--- a/src/dotnetCampus.SourceYard/Packer.cs
+++ b/src/dotnetCampus.SourceYard/Packer.cs
@@ -16,51 +16,52 @@ namespace dotnetCampus.SourceYard
         {
             Logger = new Logger();
 
-            Logger.Message("初始化打包");
+            Logger.Message(text: "初始化打包");
 
-            if (string.IsNullOrEmpty(projectFile) || !File.Exists(projectFile))
+            if (string.IsNullOrEmpty(value: projectFile) || !File.Exists(path: projectFile))
             {
-                Logger.Error($"无法从{projectFile}找到项目文件");
+                Logger.Error(text: $"无法从{projectFile}找到项目文件");
                 return;
             }
 
-            if (string.IsNullOrEmpty(intermediateDirectory))
+            if (string.IsNullOrEmpty(value: intermediateDirectory))
             {
                 // 这时的文件夹可以不存在
-                Logger.Error("无法解析文件夹 " + intermediateDirectory);
+                Logger.Error(text: "无法解析文件夹 " + intermediateDirectory);
                 return;
             }
 
-            if (string.IsNullOrEmpty(packageOutputPath))
+            if (string.IsNullOrEmpty(value: packageOutputPath))
             {
-                Logger.Error("打包输出文件夹不能为空");
+                Logger.Error(text: "打包输出文件夹不能为空");
                 return;
             }
 
-            if (string.IsNullOrEmpty(packageVersion))
+            if (string.IsNullOrEmpty(value: packageVersion))
             {
-                Logger.Error("打包版本不能为空");
+                Logger.Error(text: "打包版本不能为空");
                 return;
             }
 
-            _projectFile = Path.GetFullPath(projectFile);
-            _intermediateDirectory = Path.GetFullPath(intermediateDirectory);
-            _packageOutputPath = Path.GetFullPath(packageOutputPath);
+            _projectFile = Path.GetFullPath(path: projectFile);
+            _intermediateDirectory = Path.GetFullPath(path: intermediateDirectory);
+            _packageOutputPath = Path.GetFullPath(path: packageOutputPath);
             _packageVersion = packageVersion;
-            _packageReferenceVersion = Path.GetFullPath(packageReferenceVersion);
+            _packageReferenceVersion = Path.GetFullPath(path: packageReferenceVersion);
             BuildProps = buildProps;
             PackageId = packageId;
 
             PackagedProjectFile = new PackagedProjectFile
             (
-                compileFile: GetFile(compileFile),
-                resourceFile: GetFile(resourceFile),
-                contentFile: GetFile(contentFile),
-                embeddedResource: GetFile(embeddedResource),
-                page: GetFile(page),
-                applicationDefinition: GetFile(applicationDefinition),
-                noneFile: GetFile(noneFile),
-                projectFolder: Path.GetDirectoryName(_projectFile)
+                compileFile: GetFile(file: compileFile),
+                resourceFile: GetFile(file: resourceFile),
+                contentFile: GetFile(file: contentFile),
+                embeddedResource: GetFile(file: embeddedResource),
+                page: GetFile(file: page),
+                applicationDefinition: GetFile(file: applicationDefinition),
+                noneFile: GetFile(file: noneFile),
+                projectFolder: Path.GetDirectoryName(path: _projectFile),
+                buildProps: buildProps
             );
 
             _packers = new IPackFlow[]
@@ -72,7 +73,7 @@ namespace dotnetCampus.SourceYard
                 new NuGetPacker(),
             };
 
-            Logger.Message("初始化打包完成");
+            Logger.Message(text: "初始化打包完成");
         }
 
         internal void Pack()

--- a/src/dotnetCampus.SourceYard/Utils/BuildProps.cs
+++ b/src/dotnetCampus.SourceYard/Utils/BuildProps.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using dotnetCampus.Configurations;
 using dotnetCampus.Configurations.Core;
+using dotnetCampus.SourceYard.Context;
 
 namespace dotnetCampus.SourceYard.Utils
 {
@@ -108,6 +109,8 @@ namespace dotnetCampus.SourceYard.Utils
         /// </summary>
         public string SourcePackingDirectory { get; private set; }
 
+        public List<SourceYardPackageFile> CompileSourceYardPackageFile { private set; get; } = null!;
+
         private string _authors;
         private string _company;
 
@@ -142,8 +145,35 @@ namespace dotnetCampus.SourceYard.Utils
 
             var sourceYardPackageReferenceFile = Path.Combine(packingDirectory, "SourceYardPackageReferenceFile.txt");
 
-            List<string> sourceYardPackageReferenceList = File.ReadAllLines(sourceYardPackageReferenceFile).Where(temp=>!string.IsNullOrEmpty(temp)).ToList();
+            List<string> sourceYardPackageReferenceList = File.ReadAllLines(sourceYardPackageReferenceFile).Where(temp => !string.IsNullOrEmpty(temp)).ToList();
             SourceYardPackageReferenceList = sourceYardPackageReferenceList;
+
+            var sourceYardCompilePackageFile = Path.Combine(packingDirectory, "SourceYardCompilePackageFile.txt");
+
+            CompileSourceYardPackageFile = ParseSourceYardPackageFile(sourceYardCompilePackageFile);
+        }
+
+        private List<SourceYardPackageFile> ParseSourceYardPackageFile(string sourceYardPackageFile)
+        {
+            var sourceYardPackageFileList = new List<SourceYardPackageFile>();
+            var text = File.ReadAllText(sourceYardPackageFile);
+
+            foreach (var line in text.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))
+            {
+                var package = line.Split('|');
+                if (package.Length == 2)
+                {
+                    var sourceFile = package[0];
+                    var packagePath = package[1];
+
+                    if (!string.IsNullOrEmpty(sourceFile))
+                    {
+                        sourceYardPackageFileList.Add(new SourceYardPackageFile(new FileInfo(sourceFile), packagePath));
+                    }
+                }
+            }
+
+            return sourceYardPackageFileList;
         }
 
         /// <summary>

--- a/src/dotnetCampus.SourceYard/Utils/BuildProps.cs
+++ b/src/dotnetCampus.SourceYard/Utils/BuildProps.cs
@@ -109,8 +109,6 @@ namespace dotnetCampus.SourceYard.Utils
         /// </summary>
         public string SourcePackingDirectory { get; private set; }
 
-        public List<SourceYardPackageFile> CompileSourceYardPackageFile { private set; get; } = null!;
-
         private string _authors;
         private string _company;
 
@@ -149,31 +147,6 @@ namespace dotnetCampus.SourceYard.Utils
             SourceYardPackageReferenceList = sourceYardPackageReferenceList;
 
             var sourceYardCompilePackageFile = Path.Combine(packingDirectory, "SourceYardCompilePackageFile.txt");
-
-            CompileSourceYardPackageFile = ParseSourceYardPackageFile(sourceYardCompilePackageFile);
-        }
-
-        private List<SourceYardPackageFile> ParseSourceYardPackageFile(string sourceYardPackageFile)
-        {
-            var sourceYardPackageFileList = new List<SourceYardPackageFile>();
-            var text = File.ReadAllText(sourceYardPackageFile);
-
-            foreach (var line in text.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))
-            {
-                var package = line.Split('|');
-                if (package.Length == 2)
-                {
-                    var sourceFile = package[0];
-                    var packagePath = package[1];
-
-                    if (!string.IsNullOrEmpty(sourceFile))
-                    {
-                        sourceYardPackageFileList.Add(new SourceYardPackageFile(new FileInfo(sourceFile), packagePath));
-                    }
-                }
-            }
-
-            return sourceYardPackageFileList;
         }
 
         /// <summary>

--- a/src/dotnetCampus.SourceYard/Utils/FileSystem.cs
+++ b/src/dotnetCampus.SourceYard/Utils/FileSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using dotnetCampus.SourceYard.Context;
 
 namespace dotnetCampus.SourceYard.Utils
 {
@@ -14,19 +15,19 @@ namespace dotnetCampus.SourceYard.Utils
         /// <param name="sourceFolder"></param>
         /// <param name="targetFolder"></param>
         /// <param name="fileList"></param>
-        public static void CopyFileList(string sourceFolder, string targetFolder, List<string> fileList)
+        public static void CopyFileList(string sourceFolder, string targetFolder, List<SourceYardPackageFile> fileList)
         {
-            foreach (var file in fileList.Select(Path.GetFullPath))
+            foreach (var file in fileList)
             {
-                var relativePath = MakeRelativePath(sourceFolder, file);
-                var targetFile = Path.GetFullPath(Path.Combine(targetFolder, relativePath));
+                //var relativePath = MakeRelativePath(sourceFolder, file);
+                var targetFile = Path.GetFullPath(Path.Combine(targetFolder, file.SourcePackagePath));
                 var directory = Path.GetDirectoryName(targetFile);
                 if (directory != null && !Directory.Exists(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }
 
-                File.Copy(file, targetFile, true);
+                File.Copy(file.SourceFile.FullName, targetFile, true);
             }
         }
 

--- a/src/dotnetCampus.SourceYard/Utils/ItemGroupElement.cs
+++ b/src/dotnetCampus.SourceYard/Utils/ItemGroupElement.cs
@@ -21,12 +21,18 @@ namespace dotnetCampus.SourceYard.Utils
         public (XElement itemGroupElement, XElement itemGroupElementOfXaml) GetItemGroup()
         {
             var contextPackagedProjectFile = _contextPackagedProjectFile;
-            var compileFileList = contextPackagedProjectFile.CompileFileList;
-            var contentFileList = contextPackagedProjectFile.ContentFileList;
-            var resourceFileList = contextPackagedProjectFile.ResourceFileList;
-            var noneFileList = contextPackagedProjectFile.NoneFileList;
-            var embeddedResource = contextPackagedProjectFile.EmbeddedResourceList;
-            var pageFileList = contextPackagedProjectFile.PageList;
+            var compileFileList = contextPackagedProjectFile.CompileFileList.Select(temp => temp.SourcePackagePath)
+                .ToList();
+            var contentFileList = contextPackagedProjectFile.ContentFileList.Select(temp => temp.SourcePackagePath)
+                .ToList();
+            var resourceFileList = contextPackagedProjectFile.ResourceFileList.Select(temp => temp.SourcePackagePath)
+                .ToList();
+            var noneFileList = contextPackagedProjectFile.NoneFileList.Select(temp => temp.SourcePackagePath)
+                .ToList();
+            var embeddedResource = contextPackagedProjectFile.EmbeddedResourceList.Select(temp => temp.SourcePackagePath)
+                .ToList();
+            var pageFileList = contextPackagedProjectFile.PageList.Select(temp => temp.SourcePackagePath)
+                .ToList();
 
             var prefix = $"_{_packageGuid}";
 


### PR DESCRIPTION
Fixes #75 

Fixes dotnet-campus/SourceFusion#13

存在问题是，开发者设置了 <Compile Include="a.cs"/> 此时想要更改文件放在 NuGet 包的路径，是不支持的

	<ItemGroup>
		<SourceYardCompile Include="Foo\a.cs" SourcePackagePath="analyzer\a.cs" />
	</ItemGroup>