### PR TITLE
可以添加 NuGet 引用排除列表

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,4 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+/src/dotnetCampus.SourceYard/Properties/launchSettings.json

--- a/docs/zh-cn/IncludeSourceYardPackageReference.md
+++ b/docs/zh-cn/IncludeSourceYardPackageReference.md
@@ -1,0 +1,24 @@
+# 引用源代码包依赖的原理
+
+在 `$(PackageId).props` 文件，也就是会在打包的时候，放在打出的源代码包，作为对应的源代码包的 Build 文件夹里面控制构建的 props 文件，在这个文件里面将当前源代码包的包 Id 加入到 SourceYardPackageReference 属性里面，如下面代码
+
+```xml
+    <PropertyGroup>
+        <!-- 下面代码用来引用源代码包依赖 -->
+        <SourceYardPackageReference>$(SourceYardPackageReference);#(PackageId)</SourceYardPackageReference>
+    </PropertyGroup>
+```
+
+这样在其他的项目，安装了源代码包，就可以通过 SourceYardPackageReference 属性了解当前项目安装了哪些源代码包
+
+例如有项目 A 安装了 B 源代码包，那么通过 SourceYardPackageReference 属性就能拿到 B 源代码包
+
+在将安装了源代码包的项目打包为源代码包时，例如将上面的 A 项目打包为源代码包时，想要添加 B 源代码包的引用依赖，就可以通过 SourceYardPackageReference 属性拿到当前 A 项目安装的源代码包，将这些源代码加入到依赖中
+
+添加源代码包依赖的逻辑放在 Core.targets 里，将 SourceYardPackageReference 属性写入到 SourceYardPackageReferenceFile 文件里面
+
+```xml
+    <WriteLinesToFile File="$(SourceYardPackageReferenceFile)" Lines="$(SourceYardPackageReference)" Overwrite="true"></WriteLinesToFile>
+```
+
+这个 SourceYardPackageReferenceFile 文件将会在 BuildProps 里面读取然后加入引用依赖

--- a/docs/zh-cn/SourceYardExcludePackageReference.md
+++ b/docs/zh-cn/SourceYardExcludePackageReference.md
@@ -1,0 +1,27 @@
+# SourceYardExcludePackageReference
+
+排除的依赖引用
+
+在打源代码包的时候，有一些 NuGet 引用依赖不期望被加入源代码的依赖，以提升源代码包的兼容性
+
+此时可以采用 SourceYardExcludePackageReference 机制，在 SourceYardExcludePackageReference 项里面添加的 NuGet 包 Id 内容，将不会被加入源代码包引用依赖
+
+例如有项目 A 引用了两个 NuGet 包，分别是 B 和 C 库
+
+```xml
+  <ItemGroup>
+    <PackageReference Include="B" Version="1.0.0" />
+    <PackageReference Include="C" Version="1.0.0" />
+  </ItemGroup>
+```
+
+而项目 A 不期望打出的源代码包，包含了 B 和 C 库的依赖。可以在项目文件里面添加 SourceYardExcludePackageReference 列表，如下面代码
+
+```xml
+  <ItemGroup>
+    <SourceYardExcludePackageReference Include="B" />
+    <SourceYardExcludePackageReference Include="C" />
+  </ItemGroup>
+```
+
+此时打包出来的源代码包将不会包含 B 和 C 库的依赖

--- a/dotnetCampus.SourceYard.sln.DotSettings
+++ b/dotnetCampus.SourceYard.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SDK/@EntryIndexedValue">SDK</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=docstates/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nupkg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nuspec/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -46,7 +46,8 @@
 
     <ItemGroup>
       <!-- 这个 ItemGroup 里面存放的是加入到额外的文件引用里面 -->
-      <!-- 这里面的值最终将会写入到 SourceYardCompilePackageFile 文件 -->
+      <!-- 用于支持附加文件功能 -->
+      <!-- 这里面的 ItemGroup 所有的值最终将会写入到 SourceYardCompilePackageFile 文件 -->
       <!-- 此文件格式为每行一个文件的配置，包括文件所在的源代码路径以及放在源代码包的相对路径 -->
       <!-- 格式如下： 源代码路径 | 放在源代码包的相对路径 -->
       <!-- 如在源代码里面的 C:\dotnet-campus\F1\A.cs 需要放在源代码包里面的 F2\A1.cs 文件 -->

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -45,6 +45,12 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- 这个 ItemGroup 里面存放的是加入到额外的文件引用里面 -->
+      <!-- 这里面的值最终将会写入到 SourceYardCompilePackageFile 文件 -->
+      <!-- 此文件格式为每行一个文件的配置，包括文件所在的源代码路径以及放在源代码包的相对路径 -->
+      <!-- 格式如下： 源代码路径 | 放在源代码包的相对路径 -->
+      <!-- 如在源代码里面的 C:\dotnet-campus\F1\A.cs 需要放在源代码包里面的 F2\A1.cs 文件 -->
+      <!-- 写入到文件内容如下：C:\dotnet-campus\F1\A.cs|F2\A1.cs -->
       <_SourceYardCompilePackage Include="%(SourceYardCompile.Identity)|%(SourceYardCompile.SourcePackagePath)"/>
       <_SourceYardResourcePackage Include="%(SourceYardResource.Identity)|%(SourceYardResource.SourcePackagePath)"/>
       <_SourceYardContentPackage Include="%(SourceYardContent.Identity)|%(SourceYardContent.SourcePackagePath)"/>
@@ -52,6 +58,7 @@
       <_SourceYardEmbeddedResourcePackage Include="%(SourceYardEmbeddedResource.Identity)|%(SourceYardEmbeddedResource.SourcePackagePath)"/>
 
       <!-- 这是给 SourceFusion 预编译生成的文件加入打包 -->
+      <!-- 预编译生成的文件所在源代码包的路径和所在项目路径相同，都是 _SourceFusionIncludedCompileFile.Identity 这个值 -->
       <_SourceYardForSourceFusionCompilePackage Include="%(_SourceFusionIncludedCompileFile.Identity)|%(_SourceFusionIncludedCompileFile.Identity)"/>
     </ItemGroup>
 

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -147,6 +147,9 @@
       <!-- 给定默认的 SourceYard 路径名 -->
       <SourceYardApplicationFilePath Condition="'$(SourceYardApplicationFilePath)' == ''">$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe</SourceYardApplicationFilePath>
     </PropertyGroup>
+
+    <Error Text="Can not find SourceYardApplicationFilePath $(SourceYardApplicationFilePath)" Condition="!Exists($(SourceYardApplicationFilePath))"/>
+
     <Exec
         Command="$(SourceYardApplicationFilePath) $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) --SourcePackingDirectory $(SourcePackingDirectory) --TargetFrameworks &quot;$(TargetFrameworks) &quot; --TargetFramework &quot;$(TargetFramework) &quot;">
     </Exec>

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -37,6 +37,9 @@
       <SourceProjectPackageFile>$(SourcePackingDirectory)SourceProjectPackageFile.txt</SourceProjectPackageFile>
       <SourceYardPackageReferenceFile>$(SourcePackingDirectory)SourceYardPackageReferenceFile.txt</SourceYardPackageReferenceFile>
 
+      <!-- 表示不要包含的引用依赖列表 -->
+      <SourceYardExcludePackageReferenceFile>$(SourcePackingDirectory)SourceYardExcludePackageReferenceFile.txt</SourceYardExcludePackageReferenceFile>
+
       <SourceYardCompilePackageFile>$(SourcePackingDirectory)SourceYardCompilePackageFile.txt</SourceYardCompilePackageFile>
       <SourceYardResourcePackageFile>$(SourcePackingDirectory)SourceYardResourcePackageFile.txt</SourceYardResourcePackageFile>
       <SourceYardContentPackageFile>$(SourcePackingDirectory)SourceYardContentPackageFile.txt</SourceYardContentPackageFile>
@@ -126,6 +129,10 @@
     <WriteLinesToFile File="$(SourceYardCompilePackageFile)" Lines="@(_SourceYardCompilePackage)" Overwrite="true"></WriteLinesToFile>
     <!-- 这是给 SourceFusion 预编译生成的文件加入打包，写入在 SourceYardCompilePackageFile 文件 -->
     <WriteLinesToFile File="$(SourceYardCompilePackageFile)" Lines="@(_SourceYardForSourceFusionCompilePackage)"></WriteLinesToFile>
+    <!-- 写入表示不要包含的引用依赖列表，这部分的 NuGet 包依赖将会忽略 -->
+    <WriteLinesToFile File="$(SourceYardExcludePackageReferenceFile)"
+                      Lines="@(SourceYardExcludePackageReference)"
+                      Overwrite="true"/>
 
     <WriteLinesToFile File="$(SourceYardResourcePackageFile)" Lines="@(_SourceYardResourcePackage)" Overwrite="true"></WriteLinesToFile>
     <WriteLinesToFile File="$(SourceYardContentPackageFile)" Lines="@(_SourceYardContentPackage)" Overwrite="true"></WriteLinesToFile>

--- a/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/Core.targets
@@ -143,8 +143,12 @@
   
   <!--打包第三步，无论多框架还是单框架只执行一次-->
   <Target Name="SourceYardStep3">
+    <PropertyGroup>
+      <!-- 给定默认的 SourceYard 路径名 -->
+      <SourceYardApplicationFilePath Condition="'$(SourceYardApplicationFilePath)' == ''">$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe</SourceYardApplicationFilePath>
+    </PropertyGroup>
     <Exec
-        Command="$(MSBuildThisFileDirectory)..\tools\net45\dotnetCampus.SourceYard.exe $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) --SourcePackingDirectory $(SourcePackingDirectory) --TargetFrameworks &quot;$(TargetFrameworks) &quot; --TargetFramework &quot;$(TargetFramework) &quot;">
+        Command="$(SourceYardApplicationFilePath) $(SourceMSBuildProjectFullPath) $(SourceIntermediateDirectory) $(SourcePackageOutputPath) $(SourceYardPackageVersion) --Compile $(CompileTextFile) --Resource $(ResourceTextFile) --Content $(ContentTextFile) --Page $(PageTextFile) --ApplicationDefinition $(ApplicationDefinitionTextFile) --None $(NoneTextFile) --EmbeddedResource $(EmbeddedResourceTextFile) $(SourceYardAuthors) $(SourceYardRepositoryUrl) $(SourceYardRepositoryType) $(SourceYardPackageProjectUrl) $(SourceYardCopyright) $(SourceYardDescription) $(SourceYardTitle) $(SourceYardPackageLicenseUrl) $(SourceYardPackageReleaseNotes) $(SourceYardPackageTags) $(SourceYardOwner) $(SourceYardPackageId) $(SourcePackageReferenceVersion) --SourcePackingDirectory $(SourcePackingDirectory) --TargetFrameworks &quot;$(TargetFrameworks) &quot; --TargetFramework &quot;$(TargetFramework) &quot;">
     </Exec>
   </Target>
 

--- a/src/dotnetCampus.SourceYard/Assets/Current/build/PackageId.targets
+++ b/src/dotnetCampus.SourceYard/Assets/Current/build/PackageId.targets
@@ -4,7 +4,10 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <Import Project="..\build\Core.targets"/>
+  <!-- 在调试下的路径是不存在的 -->
+  <Import Project="..\build\Core.targets" Condition="Exists('..\build\Core.targets')" />
+  <!-- 只有调试下在存在此文件 -->
+  <Import Project="..\Core.targets" Condition="Exists('..\Core.targets')" />
 
   <!-- 单框架项目入口 -->
   <Target Name="BuildSourceNuGet" AfterTargets="Build"

--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
@@ -13,6 +13,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
+        <!-- 下面代码用来引用源代码包依赖 -->
         <SourceYardPackageReference>$(SourceYardPackageReference);#(PackageId)</SourceYardPackageReference>
     </PropertyGroup>
 </Project>

--- a/src/dotnetCampus.SourceYard/Utils/BuildProps.cs
+++ b/src/dotnetCampus.SourceYard/Utils/BuildProps.cs
@@ -142,18 +142,31 @@ namespace dotnetCampus.SourceYard.Utils
                 RepositoryUrl = configuration.GetValue("RepositoryUrl")?.Trim() ?? string.Empty;
             }
 
-            var sourceYardPackageReferenceFile = Path.Combine(packingDirectory, "SourceYardPackageReferenceFile.txt");
+            const string sourceYardPackageReferenceFile = "SourceYardPackageReferenceFile.txt";
+        
+            SourceYardPackageReferenceList = GetList(sourceYardPackageReferenceFile);
 
-            List<string> sourceYardPackageReferenceList = File.ReadAllLines(sourceYardPackageReferenceFile).Where(temp => !string.IsNullOrEmpty(temp)).ToList();
-            SourceYardPackageReferenceList = sourceYardPackageReferenceList;
-
-            var sourceYardCompilePackageFile = Path.Combine(packingDirectory, "SourceYardCompilePackageFile.txt");
+            const string sourceYardExcludePackageReferenceFile =
+                "SourceYardExcludePackageReferenceFile.txt";
+            SourceYardExcludePackageReferenceList = GetList(sourceYardExcludePackageReferenceFile);
         }
+
+        /// <summary>
+        /// 排除的依赖引用列表
+        /// </summary>
+        /// 有某些 NuGet 引用不想作为源代码的依赖，可以添加到 SourceYardExcludePackageReference 列表
+        public List<string> SourceYardExcludePackageReferenceList { get; private set; } = null!;
 
         /// <summary>
         /// 安装的源代码包列表
         /// </summary>
         /// 用于解决 https://github.com/dotnet-campus/SourceYard/issues/60
         public List<string> SourceYardPackageReferenceList { get; private set; } = null!;
+
+        private List<string> GetList(string fileName)
+        {
+            var file = Path.Combine(SourcePackingDirectory, fileName);
+            return File.ReadAllLines(file).Where(temp => !string.IsNullOrEmpty(temp)).ToList();
+        }
     }
 }

--- a/src/dotnetCampus.SourceYard/dotnetCampus.SourceYard.csproj
+++ b/src/dotnetCampus.SourceYard/dotnetCampus.SourceYard.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1138</MSBuildWarningsAsMessages>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/dotnetCampus.SourceYard/dotnetCampus.SourceYard.csproj
+++ b/src/dotnetCampus.SourceYard/dotnetCampus.SourceYard.csproj
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="dotnetCampus.CommandLine.Source" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="dotnetCampus.Configurations.Source" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Include="Walterlv.NullableAttributes.Source" Version="5.9.0" PrivateAssets="All" />
+    <PackageReference Include="dotnetCampus.Configurations.Source" Version="1.5.1" PrivateAssets="All" />
+    <PackageReference Include="Walterlv.NullableAttributes.Source" Version="5.10.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework)=='net45'">

--- a/tests/SourceYardTestDemo/Program.cs
+++ b/tests/SourceYardTestDemo/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SourceYardLaunchSettingsDemo
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/tests/SourceYardTestDemo/SourceYardTestDemo.csproj
+++ b/tests/SourceYardTestDemo/SourceYardTestDemo.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\src\dotnetCampus.SourceYard\Assets\Current\build\PackageId.props"></Import>
+  <Import Project="..\..\src\dotnetCampus.SourceYard\Assets\Current\build\PackageId.targets"></Import>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SourceYardApplicationFilePath>..\..\src\dotnetCampus.SourceYard\bin\Debug\net45\dotnetCampus.SourceYard.exe</SourceYardApplicationFilePath>
+  </PropertyGroup>
+
+  <!-- 测试排除项 -->
+  <ItemGroup>
+    <PackageReference Include="dotnetCampus.DotNETBuildSDK" Version="1.3.3" />
+    <PackageReference Include="dotnetCampus.Configurations.Source" Version="1.5.1" PrivateAssets="All" />
+    <SourceYardExcludePackageReference Include="dotnetCampus.Configurations.Source"></SourceYardExcludePackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/SourceYardTestDemo/SourceYardTestDemo.sln
+++ b/tests/SourceYardTestDemo/SourceYardTestDemo.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceYardTestDemo", "SourceYardTestDemo.csproj", "{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Release|x64.Build.0 = Release|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E80935C-6460-4DEC-8AA2-57CFB1BC2758}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/dotnetCampus.SourceYard.Tests/dotnetCampus.SourceYard.Tests.csproj
+++ b/tests/dotnetCampus.SourceYard.Tests/dotnetCampus.SourceYard.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1138</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
有一些 NuGet 引用是不想要放在源代码包引用，可以通过加入到排除列表里面这样就不会被源代码包作为引用