### PR TITLE
尝试修复兼容 SDK 逻辑导致构建失败

### DIFF
--- a/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
+++ b/src/dotnetCampus.SourceYard/Assets/Target/build/$(PackageId).props
@@ -10,6 +10,9 @@
           WPF 临时项目不会 Import NuGet 中的 props 和 targets 可能是 WPF 的 Bug，也可能是刻意如此。
           所以我们通过一个属性开关 `ShouldFixNuGetImportingBugForWpfProjects` 来决定是否修复这个错误。-->
         <ShouldFixNuGetImportingBugForWpfProjects Condition=" '$(ShouldFixNuGetImportingBugForWpfProjects)' == '' ">True</ShouldFixNuGetImportingBugForWpfProjects>
+
+        <!-- 如果在 SDK 里面默认开启了 IncludePackageReferencesDuringMarkupCompilation 选项，意味着 WPF 层已经兼容处理了，这里就不能重复兼容处理，否则将会出现包含了重复的 Compile 项构建失败 -->
+        <ShouldFixNuGetImportingBugForWpfProjects Condition=" '$(IncludePackageReferencesDuringMarkupCompilation)' == 'True' ">False</ShouldFixNuGetImportingBugForWpfProjects>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
框架层的 IncludePackageReferencesDuringMarkupCompilation 就是用来修复 XAML 构建过程找不到引用的问题，而 SourceYard 里面也修了一次，将会修了两次。修了两次将会让 Compile 引用两次