### PR TITLE
Nuspec添加命名空间

### DIFF
--- a/src/dotnetCampus.SourceYard/PackFlow/NuspecFiles/NuspecContexts/NuspecPackage.cs
+++ b/src/dotnetCampus.SourceYard/PackFlow/NuspecFiles/NuspecContexts/NuspecPackage.cs
@@ -2,7 +2,7 @@
 
 namespace dotnetCampus.SourceYard.PackFlow.NuspecFiles.NuspecContexts
 {
-    [XmlType("package")]
+    [XmlRoot("package", Namespace = "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd")]
     public class NuspecPackage
     {
         [XmlElement("metadata")]


### PR DESCRIPTION
一些包管理器(比如gitlab)会验证nuspec文件语法，缺失命名空间会报错